### PR TITLE
Setting APPLICATION_EXTENSION_API_ONLY to YES

### DIFF
--- a/Decodable.xcodeproj/project.pbxproj
+++ b/Decodable.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -597,6 +598,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Per the documentation:

```
When enabled, this causes the compiler and linker to
disallow use of APIs that are not available to
app extensions and to disallow linking to frameworks
that have not been built with this setting enabled.
```

This allows frameworks to be linked safely from extensions.