### PR TITLE
Only add Swift and header files as sources.

### DIFF
--- a/Decodable.podspec.json
+++ b/Decodable.podspec.json
@@ -18,5 +18,5 @@
     "osx": "10.9"
   },
   "requires_arc": true,
-  "source_files": "Decodable/*"
+  "source_files": "Decodable/*.{swift,h}"
 }


### PR DESCRIPTION
`xcodebuild` doesn't really seem to like putting adding an "Info.plist" to a framework's resources, I have experienced this error a lot with the old podspec:

```error: You don’t have permission to save the file “Info.plist” in the folder “Resources”.```

It seems to happen more consistently with Xcode 7.1, but in any case there's no reason for adding the Info.plist as a resource, is there?