### PR TITLE
Set the deployment target for tvOS

### DIFF
--- a/Decodable.xcodeproj/project.pbxproj
+++ b/Decodable.xcodeproj/project.pbxproj
@@ -641,6 +641,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -659,6 +660,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This prevents Xcode to automatically choosing the latest version (9.1 as for today)