### PR TITLE
Add support for specific (U)Int[16|32|64]

### DIFF
--- a/Decodable.xcodeproj/project.pbxproj
+++ b/Decodable.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		8FFAB8121B7CFA9500E2D724 /* Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFAB8111B7CFA9500E2D724 /* Parse.swift */; };
 		8FFAB8131B7CFA9500E2D724 /* Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFAB8111B7CFA9500E2D724 /* Parse.swift */; };
 		8FFAB8141B7CFA9500E2D724 /* Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFAB8111B7CFA9500E2D724 /* Parse.swift */; };
+		AB072C901C3CBD9800D6DC72 /* NumberCastable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8C1211C3CA6BE00B6D86F /* NumberCastable.swift */; };
+		AB072C911C3CBD9900D6DC72 /* NumberCastable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8C1211C3CA6BE00B6D86F /* NumberCastable.swift */; };
+		AB072C921C3CBD9900D6DC72 /* NumberCastable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8C1211C3CA6BE00B6D86F /* NumberCastable.swift */; };
 		ABA8C1221C3CA6BE00B6D86F /* NumberCastable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8C1211C3CA6BE00B6D86F /* NumberCastable.swift */; };
 		D0DC54771B78150900F79CB0 /* Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE7B57C1B4CA01400837609 /* Decodable.swift */; };
 		D0DC54781B78150900F79CB0 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F956D1E1B4D6FF700243072 /* Operators.swift */; };
@@ -483,6 +486,7 @@
 			files = (
 				8F87BCC51B592F0E00E53A8C /* DecodingError.swift in Sources */,
 				8FFAB8131B7CFA9500E2D724 /* Parse.swift in Sources */,
+				AB072C901C3CBD9800D6DC72 /* NumberCastable.swift in Sources */,
 				8F012EF61BB5A920007D0B5C /* Castable.swift in Sources */,
 				17FB810E1B5311840012F106 /* Decodable.swift in Sources */,
 				17FB810F1B5311870012F106 /* Operators.swift in Sources */,
@@ -512,6 +516,7 @@
 			files = (
 				57FCDE5B1BA283C900130C48 /* DecodingError.swift in Sources */,
 				57FCDE5C1BA283C900130C48 /* Parse.swift in Sources */,
+				AB072C921C3CBD9900D6DC72 /* NumberCastable.swift in Sources */,
 				8F012EF81BB5A928007D0B5C /* Castable.swift in Sources */,
 				57FCDE5D1BA283C900130C48 /* Decodable.swift in Sources */,
 				57FCDE5E1BA283C900130C48 /* Operators.swift in Sources */,
@@ -555,6 +560,7 @@
 			files = (
 				D0DC547A1B78150900F79CB0 /* DecodingError.swift in Sources */,
 				8FFAB8141B7CFA9500E2D724 /* Parse.swift in Sources */,
+				AB072C911C3CBD9900D6DC72 /* NumberCastable.swift in Sources */,
 				8F012EF71BB5A920007D0B5C /* Castable.swift in Sources */,
 				D0DC54771B78150900F79CB0 /* Decodable.swift in Sources */,
 				D0DC54781B78150900F79CB0 /* Operators.swift in Sources */,

--- a/Decodable.xcodeproj/project.pbxproj
+++ b/Decodable.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		8FFAB8121B7CFA9500E2D724 /* Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFAB8111B7CFA9500E2D724 /* Parse.swift */; };
 		8FFAB8131B7CFA9500E2D724 /* Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFAB8111B7CFA9500E2D724 /* Parse.swift */; };
 		8FFAB8141B7CFA9500E2D724 /* Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFAB8111B7CFA9500E2D724 /* Parse.swift */; };
+		ABA8C1221C3CA6BE00B6D86F /* NumberCastable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8C1211C3CA6BE00B6D86F /* NumberCastable.swift */; };
 		D0DC54771B78150900F79CB0 /* Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE7B57C1B4CA01400837609 /* Decodable.swift */; };
 		D0DC54781B78150900F79CB0 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F956D1E1B4D6FF700243072 /* Operators.swift */; };
 		D0DC547A1B78150900F79CB0 /* DecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F87BCC31B592F0E00E53A8C /* DecodingError.swift */; };
@@ -101,6 +102,7 @@
 		8FE7B5731B4C9FB900837609 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8FE7B57C1B4CA01400837609 /* Decodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Decodable.swift; sourceTree = "<group>"; };
 		8FFAB8111B7CFA9500E2D724 /* Parse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parse.swift; sourceTree = "<group>"; };
+		ABA8C1211C3CA6BE00B6D86F /* NumberCastable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberCastable.swift; sourceTree = "<group>"; };
 		D0DC546F1B7814D200F79CB0 /* Decodable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Decodable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF00609D1B5454F400D8CB77 /* DecodableExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodableExtensionTests.swift; sourceTree = "<group>"; };
 		FF0060A01B5464FD00D8CB77 /* MissingKey.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = MissingKey.json; path = JSONExamples/MissingKey.json; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 				8FE7B57C1B4CA01400837609 /* Decodable.swift */,
 				65DB18AF1C29AC0E003BDA5C /* RawRepresentableDecodable.swift */,
 				8F012EF41BB5A920007D0B5C /* Castable.swift */,
+				ABA8C1211C3CA6BE00B6D86F /* NumberCastable.swift */,
 				8F956D1E1B4D6FF700243072 /* Operators.swift */,
 				8FFAB8111B7CFA9500E2D724 /* Parse.swift */,
 				8F87BCC31B592F0E00E53A8C /* DecodingError.swift */,
@@ -522,6 +525,7 @@
 			files = (
 				8F87BCC41B592F0E00E53A8C /* DecodingError.swift in Sources */,
 				8FFAB8121B7CFA9500E2D724 /* Parse.swift in Sources */,
+				ABA8C1221C3CA6BE00B6D86F /* NumberCastable.swift in Sources */,
 				8F012EF51BB5A920007D0B5C /* Castable.swift in Sources */,
 				8FE7B57E1B4CA01400837609 /* Decodable.swift in Sources */,
 				8F956D1F1B4D6FF700243072 /* Operators.swift in Sources */,

--- a/Sources/NumberCastable.swift
+++ b/Sources/NumberCastable.swift
@@ -1,0 +1,62 @@
+//
+//  NumberCastable.swift
+//  Decodable
+//
+//  Created by Brian King on 1/5/16.
+//  Copyright © 2016 anviking. All rights reserved.
+//
+
+import Foundation
+
+// It's unfortunate that these types don't support downcasting from NSNumber,
+// so downcast to NSNumber and then extract the typed value.
+public protocol NumberCastable: Decodable {
+    static func fromNumber(number: NSNumber) -> Self
+}
+
+extension NumberCastable {
+    public static func decode(j: AnyObject) throws -> Self {
+        guard let result = j as? NSNumber else {
+            let info = DecodingError.Info(object: j)
+            throw DecodingError.TypeMismatch(type: j.dynamicType, expectedType: self, info: info)
+
+        }
+        return Self.fromNumber(result)
+    }
+}
+
+extension Int16: NumberCastable {
+    public static func fromNumber(number: NSNumber) -> Int16 {
+        return number.shortValue
+    }
+}
+
+extension Int32: NumberCastable {
+    public static func fromNumber(number: NSNumber) -> Int32 {
+        return number.intValue
+    }
+}
+
+extension Int64: NumberCastable {
+    public static func fromNumber(number: NSNumber) -> Int64 {
+        return number.longLongValue
+    }
+}
+
+extension UInt16: NumberCastable {
+    public static func fromNumber(number: NSNumber) -> UInt16 {
+        return number.unsignedShortValue
+    }
+}
+
+extension UInt32: NumberCastable {
+    public static func fromNumber(number: NSNumber) -> UInt32 {
+        return number.unsignedIntValue
+    }
+}
+
+extension UInt64: NumberCastable {
+    public static func fromNumber(number: NSNumber) -> UInt64 {
+        return number.unsignedLongLongValue
+    }
+}

--- a/Tests/DecodableExtensionTests.swift
+++ b/Tests/DecodableExtensionTests.swift
@@ -58,7 +58,20 @@ class DecodableExtensionTests: XCTestCase {
             XCTFail("should not throw this exception")
         }
     }
-    
+
+    func testSpecificIntDecodable() {
+        //given
+        let anyNumber = NSNumber(longLong: 100)
+        //when
+        let int64 = try! Int64.decode(anyNumber)
+        let int32 = try! Int32.decode(anyNumber)
+        let int16 = try! Int16.decode(anyNumber)
+        //then
+        XCTAssertEqual(int64, anyNumber.longLongValue)
+        XCTAssertEqual(int32, anyNumber.intValue)
+        XCTAssertEqual(int16, anyNumber.shortValue)
+    }
+
     // MARK: Double
     func testDoubleDecodable() {
         //given


### PR DESCRIPTION
This is a .... disappointing PR I hate to say it. But to use Decodable on primitives that don't downcast from NSNumber, this appears to be needed. Not sure if there's a better approach. CoreData generated primitives use the more specific Int storage. Thoughts?