### PR TITLE
Fix NSNumber conversions on 32-bit platforms

### DIFF
--- a/Sources/NSValueCastable.swift
+++ b/Sources/NSValueCastable.swift
@@ -8,17 +8,38 @@
 
 import Foundation
 
-extension Int64: NSValueCastable {}
-extension Int32: NSValueCastable {}
-extension Int16: NSValueCastable {}
-extension Int8: NSValueCastable {}
-extension UInt64: NSValueCastable {}
-extension UInt32: NSValueCastable {}
-extension UInt16: NSValueCastable {}
-extension UInt8: NSValueCastable {}
+extension Int64: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> Int64 { return n.longLongValue }
+}
+extension Int32: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> Int32 { return n.intValue }
+}
+extension Int16: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> Int16 { return n.shortValue }
+}
+extension Int8: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> Int8 { return n.charValue }
+}
+extension UInt64: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> UInt64 { return n.unsignedLongLongValue }
+}
+extension UInt32: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> UInt32 { return n.unsignedIntValue }
+}
+extension UInt16: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> UInt16 { return n.unsignedShortValue }
+}
+extension UInt8: NSNumberCastable {
+    public static func convertFrom(n: NSNumber) -> UInt8 { return n.unsignedCharValue }
+}
 
-/// Provides a default implementation of decode() which casts the object to a NSValue and unsafely casts its value as Self. Used to enable decoding to different IntegerTypes from NSNumber.
+/// Provides a default implementation of decode() which casts the object to a NSValue and unsafely casts its value as Self.
 public protocol NSValueCastable: Decodable {}
+
+/// Used to enable decoding to different IntegerTypes from NSNumber.
+public protocol NSNumberCastable: NSValueCastable {
+    static func convertFrom(n: NSNumber) -> Self
+}
 
 extension NSValueCastable {
     private typealias PointerOfSelf = UnsafeMutablePointer<Self> // Why do we have to do this?
@@ -26,10 +47,19 @@ extension NSValueCastable {
         guard let value = j as? NSValue else {
             throw TypeMismatchError(expectedType: NSValue.self, receivedType: j.dynamicType, object: j)
         }
-        
+
         let pointer = PointerOfSelf.alloc(1)
         defer { pointer.dealloc(1) }
         value.getValue(pointer)
         return pointer.move()
+    }
+}
+
+extension NSNumberCastable {
+    public static func decode(j: AnyObject) throws -> Self {
+        guard let value = j as? NSNumber else {
+            throw TypeMismatchError(expectedType: NSNumber.self, receivedType: j.dynamicType, object: j)
+        }
+        return convertFrom(value)
     }
 }

--- a/Tests/ArrayTests.swift
+++ b/Tests/ArrayTests.swift
@@ -40,7 +40,7 @@ class DecodableArrayTests: XCTestCase {
     func testDecodeOptionalDecodableArrayFailure() {
         // given
         let key = "key"
-        let value: NSArray = ["value1", "value2", 0x8BADF00D, "value3"]
+        let value: NSArray = ["value1", "value2", 0x8BAD, "value3"]
         let dictionary: NSDictionary = [key: value]
         // when
         do {

--- a/Tests/NSValueDecodableTests.swift
+++ b/Tests/NSValueDecodableTests.swift
@@ -25,12 +25,12 @@ class NSValueDecodableTests: XCTestCase {
     
     func testIntegerDecodingFromInt32() {
         let number = NSNumber(int: 100)
-        // XCTAssertEqual(try! Int64.decode(number), number.longLongValue)
+        XCTAssertEqual(try! Int64.decode(number), number.longLongValue)
         XCTAssertEqual(try! Int32.decode(number), number.intValue)
         XCTAssertEqual(try! Int16.decode(number), number.shortValue)
         XCTAssertEqual(try! Int8.decode(number), number.charValue)
         
-        // XCTAssertEqual(try! UInt64.decode(number), number.unsignedLongLongValue)
+        XCTAssertEqual(try! UInt64.decode(number), number.unsignedLongLongValue)
         XCTAssertEqual(try! UInt32.decode(number), number.unsignedIntValue)
         XCTAssertEqual(try! UInt16.decode(number), number.unsignedShortValue)
         XCTAssertEqual(try! UInt8.decode(number), number.unsignedCharValue)
@@ -39,13 +39,12 @@ class NSValueDecodableTests: XCTestCase {
     func testIntegerDecodingFromInt8() {
         let number = NSNumber(char: 100)
         
-        // It's ok
-        // XCTAssertEqual(try! Int64.decode(number), number.longLongValue)
+        XCTAssertEqual(try! Int64.decode(number), number.longLongValue)
         XCTAssertEqual(try! Int32.decode(number), number.intValue)
         XCTAssertEqual(try! Int16.decode(number), number.shortValue)
         XCTAssertEqual(try! Int8.decode(number), number.charValue)
         
-        // XCTAssertEqual(try! UInt64.decode(number), number.unsignedLongLongValue)
+        XCTAssertEqual(try! UInt64.decode(number), number.unsignedLongLongValue)
         XCTAssertEqual(try! UInt32.decode(number), number.unsignedIntValue)
         XCTAssertEqual(try! UInt16.decode(number), number.unsignedShortValue)
         XCTAssertEqual(try! UInt8.decode(number), number.unsignedCharValue)


### PR DESCRIPTION
This fixes `Int64` decoding on 32-bit platforms like the iPhone 4s.

The previous implementation copied memory from `NSValue` and this would
fail if you were going from `Int32` -> `Int64`, because the memory would
only be partially initialized. The unit tests to catch this had been
commented out.

The new approach is higher level: it uses the `NSNumber` conversion methods
to solve this problem as well as providing the expected behavior in
overflow cases (such as converting a large `Int64` to `Int32`)

This maintains backwards compatibility in case someone has added
`NSValueCastable` conformity to other types.