### PR TITLE
associatedtype DecodedType

### DIFF
--- a/Generator/Generator.swift
+++ b/Generator/Generator.swift
@@ -129,7 +129,8 @@ indirect enum Decodable {
         }
         
         let arguments = provider.takenNames.values.sort().map { $0 + ": Decodable" }
-        let generics = arguments.count > 0 ? "<\(arguments.joinWithSeparator(", "))>" : ""
+        let whereClause = provider.takenNames.values.sort().map { "\($0).DecodedType == \($0)" }.joinWithSeparator(", ")
+        let generics = arguments.count > 0 ? "<\(arguments.joinWithSeparator(", ")) where \(whereClause)>" : ""
         
         let documentation = generateDocumentationComment(behaviour)
         let throwKeyword =  "throws"

--- a/Sources/Castable.swift
+++ b/Sources/Castable.swift
@@ -13,7 +13,8 @@ public protocol Castable: Decodable {}
 extension Castable {
     public static func decode(j: AnyObject) throws -> Self {
         guard let result = j as? Self else {
-            throw TypeMismatchError(expectedType: self, receivedType: j.dynamicType, object: j)
+            let metadata = DecodingError.Metadata(object: j)
+            throw DecodingError.TypeMismatch(expected: self, actual: j.dynamicType, metadata)
         }
         return result
     }

--- a/Sources/Decodable.swift
+++ b/Sources/Decodable.swift
@@ -13,7 +13,7 @@ public protocol Decodable {
     static func decode(json: AnyObject) throws -> DecodedType
 }
 
-extension NSDictionary {
+extension NSDictionary: Decodable {
     public static func decode(j: AnyObject) throws -> NSDictionary {
         guard let result = j as? NSDictionary else {
             let metadata = DecodingError.Metadata(object: j)
@@ -23,7 +23,7 @@ extension NSDictionary {
     }
 }
 
-extension NSArray {
+extension NSArray: Decodable {
     public static func decode(j: AnyObject) throws -> NSArray {
         guard let result = j as? NSArray else {
             let metadata = DecodingError.Metadata(object: j)
@@ -32,7 +32,6 @@ extension NSArray {
         return result
     }
 }
-
 
 extension Dictionary where Key: Decodable, Value: Decodable, Key.DecodedType == Key, Value.DecodedType == Value {
     public static func decode(j: AnyObject) throws -> Dictionary {
@@ -47,6 +46,17 @@ extension Array where Element: Decodable, Element.DecodedType == Element {
         } else {
             return try decodeArray(Element.decode)(json: j)
         }
+    }
+}
+
+extension NSURL: Decodable {
+    public static func decode(json: AnyObject) throws -> NSURL {
+        let string = try String.decode(json)
+        guard let result = NSURL(string: string) else {
+            let metadata = DecodingError.Metadata(object: json)
+            throw DecodingError.RawRepresentableInitializationError(rawValue: string, metadata)
+        }
+        return result
     }
 }
 

--- a/Sources/Decodable.swift
+++ b/Sources/Decodable.swift
@@ -15,7 +15,8 @@ public protocol Decodable {
 extension NSDictionary {
     public static func decode(j: AnyObject) throws -> NSDictionary {
         guard let result = j as? NSDictionary else {
-            throw TypeMismatchError(expectedType: self, receivedType: j.dynamicType, object: j)
+            let metadata = DecodingError.Metadata(object: j)
+            throw DecodingError.TypeMismatch(expected: self, actual: j.dynamicType, metadata)
         }
         return result
     }
@@ -24,7 +25,8 @@ extension NSDictionary {
 extension NSArray {
     public static func decode(j: AnyObject) throws -> NSArray {
         guard let result = j as? NSArray else {
-            throw TypeMismatchError(expectedType: self, receivedType: j.dynamicType, object: j)
+            let metadata = DecodingError.Metadata(object: j)
+            throw DecodingError.TypeMismatch(expected: self, actual: j.dynamicType, metadata)
         }
         return result
     }

--- a/Sources/DecodingError.swift
+++ b/Sources/DecodingError.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public enum DecodingError: ErrorType {
+public enum DecodingError: ErrorType, Equatable {
     
-    public struct Metadata {
+    public struct Metadata: Equatable {
         
         public init(path: [String] = [], object: AnyObject, rootObject: AnyObject? = nil) {
             self.path = path
@@ -89,5 +89,38 @@ public enum DecodingError: ErrorType {
 // There are overloads for this
 public func ~=<T>(lhs: T.Type, rhs: Any.Type) -> Bool {
     return lhs == rhs
+}
+
+// FIXME: I'm not sure about === equality
+public func ==(lhs: DecodingError.Metadata, rhs: DecodingError.Metadata) -> Bool {
+    return lhs.object === rhs.object
+        && lhs.path == rhs.path
+        && lhs.rootObject === rhs.rootObject
+}
+
+public func ==(lhs: DecodingError, rhs: DecodingError) -> Bool {
+    switch (lhs, rhs) {
+    case let (.TypeMismatch(expected, actual, metadata), .TypeMismatch(expected2, actual2, metadata2)):
+        return expected == expected2
+            && actual == actual2
+            && metadata == metadata2
+    case let (.MissingKey(key, metadata), .MissingKey(key2, metadata2)):
+        return key == key2
+            && metadata == metadata2
+    case let (.RawRepresentableInitializationError(rawValue, metadata), .RawRepresentableInitializationError(rawValue2, metadata2)):
+        // FIXME: Might be strange
+        switch (rawValue, rawValue2, metadata == metadata2) {
+        case let (a as AnyObject, b as AnyObject, true):
+            return a === b
+        default:
+            return false
+        }
+    case (.WrappedError, .WrappedError):
+        // FIXME: What to do?
+        print("FIXME: WrappedError equality is unimplemented/not supported")
+        return false
+    default:
+        return false
+    }
 }
 

--- a/Sources/DecodingError.swift
+++ b/Sources/DecodingError.swift
@@ -38,7 +38,7 @@ public enum DecodingError: ErrorType {
     case RawRepresentableInitializationError(rawValue: Any, Metadata)
     case WrappedError(ErrorType, Metadata)
     
-    var metadata: Metadata {
+    public var metadata: Metadata {
         get {
             switch self {
             case .TypeMismatch(expected: _, actual: _, let metadata):

--- a/Sources/DecodingError.swift
+++ b/Sources/DecodingError.swift
@@ -8,86 +8,80 @@
 
 import Foundation
 
-/// Errors conforming DecodingError will be caught and rethrown in the decoding process with updated metadata.
-public protocol DecodingError: ErrorType {
-    /// The JSON key path to the object that failed to be decoded
-    var path: [String] {get set}
-
-    /// The JSON object that failed to be decoded
-    var object: AnyObject {get}
+public enum DecodingError: ErrorType {
     
-    /// The root JSON object for which the `path` can be used to find `object`
-    var rootObject: AnyObject? {get set}
-    
-    
-    var formattedPath: String {get}
-}
-
-extension DecodingError {
-    /// Represents the path to the object that failed decoding with "." as a separator.
-    public var formattedPath: String {
-        return path.joinWithSeparator(".")
-    }
-}
-
-public struct TypeMismatchError: DecodingError {
-
-    public init(expectedType: Any.Type, receivedType: Any.Type, object: AnyObject) {
-        self.expectedType = expectedType
-        self.receivedType = receivedType
-        self.object = object
-        self.path = []
-    }
-
-    public let expectedType: Any.Type
-    public let receivedType: Any.Type
-    
-    public var path: [String]
-    public let object: AnyObject
-    public var rootObject: AnyObject?
-    
-    public var debugDescription: String {
-        return "TypeMismatchError expected: \(expectedType) but \(object) is of type \(receivedType) in \(formattedPath)"    }
-}
-
-public struct MissingKeyError: DecodingError {
-
-    public let key: String
-    
-    public var path: [String]
-    public let object: AnyObject
-    public var rootObject: AnyObject?
-    
-    public init(key: String, object: AnyObject) {
-        self.key = key
-        self.object = object
-        self.path = []
+    public struct Metadata {
+        
+        public init(path: [String] = [], object: AnyObject, rootObject: AnyObject? = nil) {
+            self.path = path
+            self.object = object
+            self.rootObject = rootObject
+        }
+        
+        /// The JSON key path to the object that failed to be decoded
+        public var path: [String]
+        
+        /// The JSON object that failed to be decoded
+        public let object: AnyObject
+        
+        /// The root JSON object for which the `path` can be used to find `object`
+        public var rootObject: AnyObject?
+        
+        /// Represents the path to the object that failed decoding with "." as a separator.
+        public var formattedPath: String {
+            return path.joinWithSeparator(".")
+        }
     }
     
-    public var debugDescription: String {
-        return "Missing Key \(key) in \(formattedPath) \(object)"
-    }
-}
+    case TypeMismatch(expected: Any.Type, actual: Any.Type, Metadata)
+    case MissingKey(String, Metadata)
+    case RawRepresentableInitializationError(rawValue: Any, Metadata)
+    case WrappedError(ErrorType, Metadata)
+    
+    var metadata: Metadata {
+        get {
+            switch self {
+            case .TypeMismatch(expected: _, actual: _, let metadata):
+                return metadata
+            case .MissingKey(_, let metadata):
+                return metadata
+            case .RawRepresentableInitializationError(_, let metadata):
+                return metadata
+            case .WrappedError(_, let metadata):
+                return metadata
+            }
+        }
+        
+        set {
+            switch self {
+            case let .TypeMismatch(expected, actual, _):
+                self = .TypeMismatch(expected: expected, actual: actual, newValue)
+            case let .MissingKey(key, _):
+                self = .MissingKey(key, newValue)
+            case let .RawRepresentableInitializationError(rawValue, _):
+                self = RawRepresentableInitializationError(rawValue: rawValue, newValue)
+            case let .WrappedError(error, _):
+                self = .WrappedError(error, newValue)
+            }
+        }
 
-public struct RawRepresentableInitializationError: DecodingError {
-    public let type: Any.Type
-    public let rawValue: Any
-    
-    public var path: [String]
-    public let object: AnyObject
-    public var rootObject: AnyObject?
-    
-    public init(type: Any.Type, rawValue: Any, object: AnyObject) {
-        self.rawValue = rawValue
-        self.type = type
-        self.object = object
-        self.path = []
     }
     
     public var debugDescription: String {
-        return "RawRepresentableInitializationError: \(rawValue) could not be used to initialize \(type). (path: \(path))"
+        switch self {
+        case let .TypeMismatch(expected, actual, metadata):
+            return "TypeMismatchError expected: \(expected) but \(metadata.object) is of type \(actual) in \(metadata.formattedPath)"
+        case let .MissingKey(key, metadata):
+            return "Missing Key \(key) in \(metadata.formattedPath) \(metadata.object)"
+        case let .RawRepresentableInitializationError(rawValue, metadata):
+            return "RawRepresentableInitializationError: \(rawValue) could not be used to initialize \("TYPE"). (path: \(metadata.formattedPath))" // FIXME
+        case let .WrappedError(error, _):
+            return "\(error)"
+        }
     }
+    
 }
+
 
 // Allow types to be used in pattern matching
 // E.g case TypeMismatchError(NSNull.self, _, _) but be careful

--- a/Sources/NSValueCastable.swift
+++ b/Sources/NSValueCastable.swift
@@ -45,7 +45,8 @@ extension NSValueCastable {
     private typealias PointerOfSelf = UnsafeMutablePointer<Self> // Why do we have to do this?
     public static func decode(j: AnyObject) throws -> Self {
         guard let value = j as? NSValue else {
-            throw TypeMismatchError(expectedType: NSValue.self, receivedType: j.dynamicType, object: j)
+            let metadata = DecodingError.Metadata(object: j)
+            throw DecodingError.TypeMismatch(expected: NSValue.self, actual: j.dynamicType, metadata)
         }
 
         let pointer = PointerOfSelf.alloc(1)
@@ -58,7 +59,8 @@ extension NSValueCastable {
 extension NSNumberCastable {
     public static func decode(j: AnyObject) throws -> Self {
         guard let value = j as? NSNumber else {
-            throw TypeMismatchError(expectedType: NSNumber.self, receivedType: j.dynamicType, object: j)
+            let metadata = DecodingError.Metadata(object: j)
+            throw DecodingError.TypeMismatch(expected: NSValue.self, actual: j.dynamicType, metadata)
         }
         return convertFrom(value)
     }

--- a/Sources/Overloads.swift
+++ b/Sources/Overloads.swift
@@ -17,7 +17,7 @@
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A]?]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
@@ -29,7 +29,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A]?]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
@@ -41,7 +41,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]?]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B]?]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -53,7 +53,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]?]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B]?]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -65,7 +65,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [A?]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(catchNull(A.decode))))
 }
 
@@ -77,7 +77,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [A?]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(catchNull(A.decode))))
 }
 
@@ -89,7 +89,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A?]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
@@ -101,7 +101,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A?]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
@@ -113,7 +113,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -125,7 +125,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A]]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -137,7 +137,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]]? 
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -149,7 +149,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B]]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -161,7 +161,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(A.decode))))
 }
 
@@ -173,7 +173,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(A.decode))))
 }
 
@@ -185,7 +185,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B?]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -197,7 +197,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B?]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -209,7 +209,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -221,7 +221,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B]]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -233,7 +233,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -245,7 +245,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C]]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -257,7 +257,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B]]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -269,7 +269,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B]]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -281,7 +281,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [A]? {
     return try parse(json, path: [path], decode: catchNull(decodeArray(A.decode)))
 }
 
@@ -293,7 +293,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A]? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [A]? {
     return try parse(json, path: path, decode: catchNull(decodeArray(A.decode)))
 }
 
@@ -305,7 +305,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]?]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B]?]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
@@ -317,7 +317,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]?]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B]?]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
@@ -329,7 +329,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]?]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C]?]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -341,7 +341,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]?]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C]?]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -353,7 +353,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B?]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: B?]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
@@ -365,7 +365,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B?]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: B?]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
@@ -377,7 +377,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B?]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
@@ -389,7 +389,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B?]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
@@ -401,7 +401,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
@@ -413,7 +413,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B]]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
@@ -425,7 +425,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -437,7 +437,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C]]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -449,7 +449,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
@@ -461,7 +461,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
@@ -473,7 +473,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C?]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -485,7 +485,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C?]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -497,7 +497,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -509,7 +509,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C]]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -521,7 +521,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -533,7 +533,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -545,7 +545,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C]]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -557,7 +557,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]]? {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C]]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -569,7 +569,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: B]? {
     return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
@@ -581,7 +581,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B]? {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: B]? {
     return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
@@ -593,7 +593,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> A? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> A? {
     return try parse(json, path: [path], decode: catchNull(A.decode))
 }
 
@@ -605,7 +605,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> A? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> A? {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> A? {
     return try parse(json, path: path, decode: catchNull(A.decode))
 }
 
@@ -616,7 +616,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> A? {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A?]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
 }
 
@@ -627,7 +627,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A?]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
 }
 
@@ -638,7 +638,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A]]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -649,7 +649,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A]]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -660,7 +660,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]?] 
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B]]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -671,7 +671,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B]]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -682,7 +682,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(A.decode))))
 }
 
@@ -693,7 +693,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(A.decode))))
 }
 
@@ -704,7 +704,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B?]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -715,7 +715,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B?]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -726,7 +726,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B]]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -737,7 +737,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B]]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -748,7 +748,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C]]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -759,7 +759,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C]]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -770,7 +770,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B]?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -781,7 +781,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B]?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -792,7 +792,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [A?] {
     return try parse(json, path: [path], decode: decodeArray(catchNull(A.decode)))
 }
 
@@ -803,7 +803,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [A?] {
     return try parse(json, path: path, decode: decodeArray(catchNull(A.decode)))
 }
 
@@ -814,7 +814,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]?]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A]?]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
@@ -825,7 +825,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]?]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]?]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A]?]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
@@ -836,7 +836,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]?]] 
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B]?]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -847,7 +847,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B]?]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -858,7 +858,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A?]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(catchNull(A.decode))))
 }
 
@@ -869,7 +869,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A?]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(catchNull(A.decode))))
 }
 
@@ -880,7 +880,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A?]]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A?]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
@@ -891,7 +891,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A?]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A?]]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A?]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
@@ -902,7 +902,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A?]]] 
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[[A]]]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[[A]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -913,7 +913,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[[A]]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[[A]]]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[[A]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -924,7 +924,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[[A]]]]
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[[A: B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[[A: B]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -935,7 +935,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[[A: B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[[A: B]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -946,7 +946,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(A.decode))))
 }
 
@@ -957,7 +957,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(A.decode))))
 }
 
@@ -968,7 +968,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B?]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B?]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -979,7 +979,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B?]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B?]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -990,7 +990,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: [B]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -1001,7 +1001,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: [B]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -1012,7 +1012,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B: C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[[A: [B: C]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1023,7 +1023,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B: C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[[A: [B: C]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1034,7 +1034,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -1045,7 +1045,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B]]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -1056,7 +1056,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A]] {
     return try parse(json, path: [path], decode: decodeArray(decodeArray(A.decode)))
 }
 
@@ -1067,7 +1067,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A]] {
     return try parse(json, path: path, decode: decodeArray(decodeArray(A.decode)))
 }
 
@@ -1078,7 +1078,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B]?]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
@@ -1089,7 +1089,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B]?]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
@@ -1100,7 +1100,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C]?]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1111,7 +1111,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C]?]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1122,7 +1122,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B?]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
@@ -1133,7 +1133,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B?]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
@@ -1144,7 +1144,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B?]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B?]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
@@ -1155,7 +1155,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B?]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B?]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
@@ -1166,7 +1166,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [[B]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
@@ -1177,7 +1177,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [[B]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
@@ -1188,7 +1188,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B: C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [[B: C]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1199,7 +1199,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B: C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [[B: C]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1210,7 +1210,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
@@ -1221,7 +1221,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
@@ -1232,7 +1232,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C?]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -1243,7 +1243,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C?]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -1254,7 +1254,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: [C]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -1265,7 +1265,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: [C]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -1276,7 +1276,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C: D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [[A: [B: [C: D]]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1287,7 +1287,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C: D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [[A: [B: [C: D]]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1298,7 +1298,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C]]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -1309,7 +1309,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C]]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -1320,7 +1320,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B]] {
     return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
@@ -1331,7 +1331,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B]] {
     return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
@@ -1342,7 +1342,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [A] {
     return try parse(json, path: [path], decode: decodeArray(A.decode))
 }
 
@@ -1353,7 +1353,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A] {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [A] {
     return try parse(json, path: path, decode: decodeArray(A.decode))
 }
 
@@ -1364,7 +1364,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B?]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
 }
 
@@ -1375,7 +1375,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B?]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
 }
 
@@ -1386,7 +1386,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B]]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -1397,7 +1397,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B]]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -1408,7 +1408,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C]]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1419,7 +1419,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C]]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1430,7 +1430,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
 }
 
@@ -1441,7 +1441,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
 }
 
@@ -1452,7 +1452,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C?]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -1463,7 +1463,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C?]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -1474,7 +1474,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C]]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -1485,7 +1485,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C]]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -1496,7 +1496,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1507,7 +1507,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1518,7 +1518,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C]?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -1529,7 +1529,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]?] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C]?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -1540,7 +1540,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: B?] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
 }
 
@@ -1551,7 +1551,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B?] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: B?] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
 }
 
@@ -1562,7 +1562,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B]?]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
 }
 
@@ -1573,7 +1573,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B]?]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
 }
 
@@ -1584,7 +1584,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C]?]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1595,7 +1595,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C]?]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1606,7 +1606,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B?]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
 }
 
@@ -1617,7 +1617,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B?]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
 }
 
@@ -1628,7 +1628,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B?]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B?]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
 }
 
@@ -1639,7 +1639,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B?]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B?]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
 }
 
@@ -1650,7 +1650,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[[B]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -1661,7 +1661,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B]]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[[B]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -1672,7 +1672,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B: C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[[B: C]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1683,7 +1683,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B: C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[[B: C]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -1694,7 +1694,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
 }
 
@@ -1705,7 +1705,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
 }
 
@@ -1716,7 +1716,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C?]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -1727,7 +1727,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C?]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -1738,7 +1738,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: [C]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -1749,7 +1749,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: [C]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -1760,7 +1760,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C: D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [[B: [C: D]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1771,7 +1771,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C: D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [[B: [C: D]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1782,7 +1782,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -1793,7 +1793,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -1804,7 +1804,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
 }
 
@@ -1815,7 +1815,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
 }
 
@@ -1826,7 +1826,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C]?]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
 }
 
@@ -1837,7 +1837,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C]?]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
 }
 
@@ -1848,7 +1848,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D]?]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1859,7 +1859,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]?]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1870,7 +1870,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C?]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
 }
 
@@ -1881,7 +1881,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C?]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
 }
 
@@ -1892,7 +1892,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C?]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
 }
 
@@ -1903,7 +1903,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C?]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
 }
 
@@ -1914,7 +1914,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [[C]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
 }
 
@@ -1925,7 +1925,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [[C]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
 }
 
@@ -1936,7 +1936,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C: D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [[C: D]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1947,7 +1947,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C: D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [[C: D]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -1958,7 +1958,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
 }
 
@@ -1969,7 +1969,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
 }
 
@@ -1980,7 +1980,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D?]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
 }
 
@@ -1991,7 +1991,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D?]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D?]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
 }
 
@@ -2002,7 +2002,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: [D]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
 }
 
@@ -2013,7 +2013,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
 }
 
@@ -2024,7 +2024,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D: E]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D, E.DecodedType == E>(json: AnyObject, path: String)throws-> [A: [B: [C: [D: E]]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
 }
 
@@ -2035,7 +2035,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decod
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D: E]]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D, E.DecodedType == E>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D: E]]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
 }
 
@@ -2046,7 +2046,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decod
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
 }
 
@@ -2057,7 +2057,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]] {
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
 }
 
@@ -2068,7 +2068,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C]] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
 }
 
@@ -2079,7 +2079,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]] {
+public func => <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C]] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
 }
 
@@ -2090,7 +2090,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: B] {
     return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
 }
 
@@ -2101,7 +2101,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B] {
+public func => <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: B] {
     return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
 }
 
@@ -2112,7 +2112,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> A {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> A {
     return try parse(json, path: [path], decode: A.decode)
 }
 
@@ -2123,7 +2123,7 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> A {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> A {
+public func => <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> A {
     return try parse(json, path: path, decode: A.decode)
 }
 
@@ -2133,7 +2133,7 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> A {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A?]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
 }
 
@@ -2143,7 +2143,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]?]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A?]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
 }
 
@@ -2153,7 +2153,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]?]?
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -2163,7 +2163,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]?]? 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -2173,7 +2173,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]?]
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -2183,7 +2183,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -2193,7 +2193,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(A.decode))))
 }
 
@@ -2203,7 +2203,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(A.decode))))
 }
 
@@ -2213,7 +2213,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?]? 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B?]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -2223,7 +2223,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B?]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -2233,7 +2233,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -2243,7 +2243,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -2253,7 +2253,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2263,7 +2263,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2273,7 +2273,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -2283,7 +2283,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -2293,7 +2293,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [A?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [A?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(A.decode)))
 }
 
@@ -2303,7 +2303,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [A?]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [A?]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [A?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(A.decode)))
 }
 
@@ -2313,7 +2313,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [A?]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]?]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
@@ -2323,7 +2323,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]?]]? 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]?]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
@@ -2333,7 +2333,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]?]]
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -2343,7 +2343,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -2353,7 +2353,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(catchNull(A.decode))))
 }
 
@@ -2363,7 +2363,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(catchNull(A.decode))))
 }
 
@@ -2373,7 +2373,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]]? 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A?]]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
@@ -2383,7 +2383,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A?]]]? 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A?]]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
@@ -2393,7 +2393,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A?]]]
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[[A]]]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[[A]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -2403,7 +2403,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[[A]]]]?
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[[A]]]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[[A]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
@@ -2413,7 +2413,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[[A]]]
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[[A: B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[[A: B]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -2423,7 +2423,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[[A: B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[[A: B]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
@@ -2433,7 +2433,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[[A]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(A.decode))))
 }
 
@@ -2443,7 +2443,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[[A]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(A.decode))))
 }
 
@@ -2453,7 +2453,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]]?
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B?]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -2463,7 +2463,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B?]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
@@ -2473,7 +2473,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: [B]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -2483,7 +2483,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: [B]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
@@ -2493,7 +2493,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B: C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[[A: [B: C]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2503,7 +2503,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B: C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[[A: [B: C]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2513,7 +2513,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[[A: B]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -2523,7 +2523,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[[A: B]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
@@ -2533,7 +2533,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [[A]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(A.decode)))
 }
 
@@ -2543,7 +2543,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A]]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [[A]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(A.decode)))
 }
 
@@ -2553,7 +2553,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
@@ -2563,7 +2563,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
@@ -2573,7 +2573,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2583,7 +2583,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2593,7 +2593,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
@@ -2603,7 +2603,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
@@ -2613,7 +2613,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B?]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
@@ -2623,7 +2623,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B?]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
@@ -2633,7 +2633,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [[B]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
@@ -2643,7 +2643,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [[B]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
@@ -2653,7 +2653,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B: C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [[B: C]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2663,7 +2663,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B: C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [[B: C]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2673,7 +2673,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: [B]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
@@ -2683,7 +2683,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: [B]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
@@ -2693,7 +2693,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -2703,7 +2703,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -2713,7 +2713,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: [C]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -2723,7 +2723,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: [C]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -2733,7 +2733,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C: D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [[A: [B: [C: D]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -2743,7 +2743,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C: D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [[A: [B: [C: D]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -2753,7 +2753,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [[A: [B: C]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -2763,7 +2763,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [[A: [B: C]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -2773,7 +2773,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [[A: B]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
@@ -2783,7 +2783,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [[A: B]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
@@ -2793,7 +2793,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [A]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> [A]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(A.decode))
 }
 
@@ -2803,7 +2803,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [A]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [A]? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> [A]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(A.decode))
 }
 
@@ -2813,7 +2813,7 @@ public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [A]? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B?]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
 }
 
@@ -2823,7 +2823,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B?]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
 }
 
@@ -2833,7 +2833,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -2843,7 +2843,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -2853,7 +2853,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2863,7 +2863,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -2873,7 +2873,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
 }
 
@@ -2883,7 +2883,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
 }
 
@@ -2893,7 +2893,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C?]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -2903,7 +2903,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C?]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -2913,7 +2913,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -2923,7 +2923,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -2933,7 +2933,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -2943,7 +2943,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -2953,7 +2953,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C]?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -2963,7 +2963,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]?]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C]?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -2973,7 +2973,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: B?]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
 }
 
@@ -2983,7 +2983,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B?]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: B?]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
 }
 
@@ -2993,7 +2993,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
 }
 
@@ -3003,7 +3003,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
 }
 
@@ -3013,7 +3013,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -3023,7 +3023,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -3033,7 +3033,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
 }
 
@@ -3043,7 +3043,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
 }
 
@@ -3053,7 +3053,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B?]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
 }
 
@@ -3063,7 +3063,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B?]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
 }
 
@@ -3073,7 +3073,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[[B]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -3083,7 +3083,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B]]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[[B]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
 }
 
@@ -3093,7 +3093,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B: C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[[B: C]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -3103,7 +3103,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B: C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[[B: C]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
@@ -3113,7 +3113,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [[B]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
 }
 
@@ -3123,7 +3123,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [[B]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
 }
 
@@ -3133,7 +3133,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -3143,7 +3143,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
@@ -3153,7 +3153,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: [C]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -3163,7 +3163,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: [C]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
@@ -3173,7 +3173,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C: D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [[B: [C: D]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -3183,7 +3183,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C: D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [[B: [C: D]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -3193,7 +3193,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [[B: C]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -3203,7 +3203,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [[B: C]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
@@ -3213,7 +3213,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: [B]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
 }
 
@@ -3223,7 +3223,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: [B]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
 }
 
@@ -3233,7 +3233,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
 }
 
@@ -3243,7 +3243,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
 }
 
@@ -3253,7 +3253,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D]?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -3263,7 +3263,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -3273,7 +3273,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C?]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
 }
 
@@ -3283,7 +3283,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C?]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
 }
 
@@ -3293,7 +3293,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
 }
 
@@ -3303,7 +3303,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
 }
 
@@ -3313,7 +3313,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [[C]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
 }
 
@@ -3323,7 +3323,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [[C]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
 }
 
@@ -3333,7 +3333,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C: D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [[C: D]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -3343,7 +3343,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C: D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [[C: D]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
@@ -3353,7 +3353,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: [C]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
 }
 
@@ -3363,7 +3363,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: [C]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
 }
 
@@ -3373,7 +3373,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D?]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
 }
 
@@ -3383,7 +3383,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D?]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D?]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
 }
 
@@ -3393,7 +3393,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: [D]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
 }
 
@@ -3403,7 +3403,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
 }
 
@@ -3413,7 +3413,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D: E]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D, E.DecodedType == E>(json: AnyObject, path: String)throws-> [A: [B: [C: [D: E]]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
 }
 
@@ -3423,7 +3423,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D: E]]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D, E.DecodedType == E>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D: E]]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
 }
 
@@ -3433,7 +3433,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
 }
 
@@ -3443,7 +3443,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C, D.DecodedType == D>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
 }
 
@@ -3453,7 +3453,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: String)throws-> [A: [B: C]]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
 }
 
@@ -3463,7 +3463,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]]? {
+public func =>? <A: Decodable, B: Decodable, C: Decodable where A.DecodedType == A, B.DecodedType == B, C.DecodedType == C>(json: AnyObject, path: [String])throws-> [A: [B: C]]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
 }
 
@@ -3473,7 +3473,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: String)throws-> [A: B]? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
 }
 
@@ -3483,7 +3483,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B]? {
+public func =>? <A: Decodable, B: Decodable where A.DecodedType == A, B.DecodedType == B>(json: AnyObject, path: [String])throws-> [A: B]? {
     return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
 }
 
@@ -3493,7 +3493,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> A? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: String)throws-> A? {
     return try parseAndAcceptMissingKey(json, path: [path], decode: A.decode)
 }
 
@@ -3503,6 +3503,6 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> A? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> A? {
+public func =>? <A: Decodable where A.DecodedType == A>(json: AnyObject, path: [String])throws-> A? {
     return try parseAndAcceptMissingKey(json, path: path, decode: A.decode)
 }

--- a/Sources/RawRepresentableDecodable.swift
+++ b/Sources/RawRepresentableDecodable.swift
@@ -17,7 +17,8 @@ public extension RawRepresentable where RawValue: Decodable, Self: Decodable {
     static func decode(json: AnyObject) throws -> Self {
         let rawValue = try RawValue.decode(json)
         guard let rawRepresentable = Self(rawValue: rawValue) else {
-            throw RawRepresentableInitializationError(type: self, rawValue: rawValue, object: json)
+            let metadata = DecodingError.Metadata(object: json)
+            throw DecodingError.RawRepresentableInitializationError(rawValue: rawValue, metadata)
         }
         return rawRepresentable
     }

--- a/Sources/RawRepresentableDecodable.swift
+++ b/Sources/RawRepresentableDecodable.swift
@@ -12,8 +12,7 @@
  * I could not find a way to implicitly declare RawRepresentable conforming to Decodable, what would make all enums Decodable automatically.
  * Because of that for an enum to be compatible with Decodable operators it must be declared as implementing Decodable protocol.
  */
-public extension RawRepresentable where RawValue: Decodable, Self: Decodable {
-    
+public extension RawRepresentable where RawValue: Decodable, Self: Decodable, RawValue.DecodedType == RawValue {
     static func decode(json: AnyObject) throws -> Self {
         let rawValue = try RawValue.decode(json)
         guard let rawRepresentable = Self(rawValue: rawValue) else {


### PR DESCRIPTION
Building upon #79, this makes Decodable more similar to Argo and makes class conformance to `Decodable` less painful. Have not used this a lot yet, so not fully aware of the effects yet.

The following types now conform to `Decodable`:
- `NSArray`
- `NSDictionary`
- `NSURL`

Waiting with possibly completing/merging this until official Swift 3 beta. "Complete generics" might also create a choice between this and other features. And, if Foundation classes are made final or the underlying JSON Deserialization is changed for a more swifty version this is most likely overkill. Personally need it now though.

Todo:
- [ ] Fix tests
- [ ] What to do with `decodeAsOneOf `