### PR TITLE
Adds `CustomDebugStringConvertible` specification.

### DIFF
--- a/Sources/DecodingError.swift
+++ b/Sources/DecodingError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Errors conforming DecodingError will be caught and rethrown in the decoding process with updated metadata.
-public protocol DecodingError: ErrorProtocol {
+public protocol DecodingError: ErrorProtocol, CustomDebugStringConvertible {
     /// The JSON key path to the object that failed to be decoded
     var path: [String] {get set}
 


### PR DESCRIPTION
Allows `debugDescription` to be called from a `DecodingError`

Since all of the conforming structs already support the method call, doesn't require any extra code.