### PR TITLE
Add KeyPath struct

### DIFF
--- a/Decodable.xcodeproj/project.pbxproj
+++ b/Decodable.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		8F87BCC41B592F0E00E53A8C /* DecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F87BCC31B592F0E00E53A8C /* DecodingError.swift */; };
 		8F87BCC51B592F0E00E53A8C /* DecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F87BCC31B592F0E00E53A8C /* DecodingError.swift */; };
 		8F956D1F1B4D6FF700243072 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F956D1E1B4D6FF700243072 /* Operators.swift */; };
+		8FB48ECA1D306C4700BC50A1 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB48EC91D306C4700BC50A1 /* KeyPath.swift */; };
+		8FB48ECB1D306C4700BC50A1 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB48EC91D306C4700BC50A1 /* KeyPath.swift */; };
+		8FB48ECC1D306C4700BC50A1 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB48EC91D306C4700BC50A1 /* KeyPath.swift */; };
+		8FB48ECD1D306C4700BC50A1 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB48EC91D306C4700BC50A1 /* KeyPath.swift */; };
 		8FD3D92F1C270A2D00D1AF4E /* MissingKeyOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD3D92E1C270A2D00D1AF4E /* MissingKeyOperatorTests.swift */; };
 		8FD3D9301C270A2D00D1AF4E /* MissingKeyOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD3D92E1C270A2D00D1AF4E /* MissingKeyOperatorTests.swift */; };
 		8FE7B5661B4C9FB900837609 /* Decodable.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FE7B5651B4C9FB900837609 /* Decodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -113,6 +117,7 @@
 		8F87BCBA1B580CE200E53A8C /* ErrorPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorPathTests.swift; sourceTree = "<group>"; };
 		8F87BCC31B592F0E00E53A8C /* DecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodingError.swift; sourceTree = "<group>"; };
 		8F956D1E1B4D6FF700243072 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		8FB48EC91D306C4700BC50A1 /* KeyPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
 		8FD3D92E1C270A2D00D1AF4E /* MissingKeyOperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissingKeyOperatorTests.swift; sourceTree = "<group>"; };
 		8FE7B5621B4C9FB900837609 /* Decodable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Decodable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8FE7B5651B4C9FB900837609 /* Decodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Decodable.h; sourceTree = "<group>"; };
@@ -223,6 +228,7 @@
 				8F012EEF1BB414D4007D0B5C /* Playground.playground */,
 				65DB18AF1C29AC0E003BDA5C /* RawRepresentableDecodable.swift */,
 				8F72DC551C3CB8C500A39E10 /* NSValueCastable.swift */,
+				8FB48EC91D306C4700BC50A1 /* KeyPath.swift */,
 				8F956D1E1B4D6FF700243072 /* Operators.swift */,
 				8F00623E1C81EF61007BCF48 /* Overloads.swift */,
 				8FE7B57C1B4CA01400837609 /* Decodable.swift */,
@@ -584,6 +590,7 @@
 				8F87BCC51B592F0E00E53A8C /* DecodingError.swift in Sources */,
 				8FFAB8131B7CFA9500E2D724 /* Parse.swift in Sources */,
 				8F012EF61BB5A920007D0B5C /* Castable.swift in Sources */,
+				8FB48ECB1D306C4700BC50A1 /* KeyPath.swift in Sources */,
 				17FB810E1B5311840012F106 /* Decodable.swift in Sources */,
 				17FB810F1B5311870012F106 /* Operators.swift in Sources */,
 				8F0062401C81EF61007BCF48 /* Overloads.swift in Sources */,
@@ -618,6 +625,7 @@
 				57FCDE5B1BA283C900130C48 /* DecodingError.swift in Sources */,
 				57FCDE5C1BA283C900130C48 /* Parse.swift in Sources */,
 				8F012EF81BB5A928007D0B5C /* Castable.swift in Sources */,
+				8FB48ECD1D306C4700BC50A1 /* KeyPath.swift in Sources */,
 				57FCDE5D1BA283C900130C48 /* Decodable.swift in Sources */,
 				57FCDE5E1BA283C900130C48 /* Operators.swift in Sources */,
 				8F0062421C81EF61007BCF48 /* Overloads.swift in Sources */,
@@ -633,6 +641,7 @@
 				8F87BCC41B592F0E00E53A8C /* DecodingError.swift in Sources */,
 				8FFAB8121B7CFA9500E2D724 /* Parse.swift in Sources */,
 				8F012EF51BB5A920007D0B5C /* Castable.swift in Sources */,
+				8FB48ECA1D306C4700BC50A1 /* KeyPath.swift in Sources */,
 				8FE7B57E1B4CA01400837609 /* Decodable.swift in Sources */,
 				8F72DC561C3CB8C500A39E10 /* NSValueCastable.swift in Sources */,
 				8F00623F1C81EF61007BCF48 /* Overloads.swift in Sources */,
@@ -667,6 +676,7 @@
 				D0DC547A1B78150900F79CB0 /* DecodingError.swift in Sources */,
 				8FFAB8141B7CFA9500E2D724 /* Parse.swift in Sources */,
 				8F012EF71BB5A920007D0B5C /* Castable.swift in Sources */,
+				8FB48ECC1D306C4700BC50A1 /* KeyPath.swift in Sources */,
 				D0DC54771B78150900F79CB0 /* Decodable.swift in Sources */,
 				D0DC54781B78150900F79CB0 /* Operators.swift in Sources */,
 				8F0062411C81EF61007BCF48 /* Overloads.swift in Sources */,

--- a/Generator/Generator.swift
+++ b/Generator/Generator.swift
@@ -131,10 +131,8 @@ indirect enum Decodable {
         
         let documentation = generateDocumentationComment(behaviour)
         let throwKeyword =  "throws"
-        return [documentation + "public func \(operatorString) \(generics)(json: AnyObject, path: String)\(throwKeyword)-> \(returnType) {\n" +
-            "    return try \(parseCallString)(json, path: [path], decode: \(decodeClosure(provider)))\n" +
-            "}", documentation + "public func \(operatorString) \(generics)(json: AnyObject, path: [String])\(throwKeyword)-> \(returnType) {\n" +
-                "    return try \(parseCallString)(json, path: path, decode: \(decodeClosure(provider)))\n" +
+        return [documentation + "public func \(operatorString) \(generics)(json: AnyObject, keyPath: KeyPath)\(throwKeyword)-> \(returnType) {\n" +
+            "    return try \(parseCallString)(json, keyPath: keyPath, decode: \(decodeClosure(provider)))\n" +
             "}"
         ]
     }

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -8,9 +8,16 @@
 
 import Foundation
 
+/// `KeyPath` represents the path to a specific node in a tree of nested dictionaries.
+///
+/// Can be created from string and array literals and can be joined by the `=>` operator.
+/// ```
+/// let a: KeyPath = "a"
+/// let b: KeyPath = ["a", "b"]
+/// let c: KeyPath = "a" => "b" => "c"
+/// ```
 public struct KeyPath: StringLiteralConvertible, ArrayLiteralConvertible {
     var keys: [String]
-    
     public init(_ keys: [String]) {
         self.keys = keys
     }

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -1,0 +1,33 @@
+//
+//  KeyPath.swift
+//  Decodable
+//
+//  Created by Johannes Lund on 2016-07-09.
+//  Copyright © 2016 anviking. All rights reserved.
+//
+
+import Foundation
+
+public struct KeyPath: StringLiteralConvertible, ArrayLiteralConvertible {
+    var keys: [String]
+    
+    public init(keys: [String]) {
+        self.keys = keys
+    }
+    
+    public init(stringLiteral value: String) {
+        self.keys = [value]
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.keys = [value]
+    }
+    
+    public init(unicodeScalarLiteral value: String) {
+        self.keys = [value]
+    }
+    
+    public init(arrayLiteral elements: String...) {
+        self.keys = elements
+    }
+}

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -11,8 +11,12 @@ import Foundation
 public struct KeyPath: StringLiteralConvertible, ArrayLiteralConvertible {
     var keys: [String]
     
-    public init(keys: [String]) {
+    public init(_ keys: [String]) {
         self.keys = keys
+    }
+    
+    public init(_ key: String) {
+        self.keys = [key]
     }
     
     public init(stringLiteral value: String) {

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -29,12 +29,8 @@ public func =>? (lhs: AnyObject, rhs: KeyPath) throws -> AnyObject? {
 
 /// Enables parsing nested objects e.g json => "a" => "b"
 
-public func => (lhs: String, rhs: String) -> KeyPath {
-    return KeyPath([lhs, rhs])
-}
-
-public func => (lhs: String, rhs: KeyPath) -> KeyPath {
-    return KeyPath([lhs] + rhs.keys)
+public func => (lhs: KeyPath, rhs: KeyPath) -> KeyPath {
+    return KeyPath(lhs.keys + rhs.keys)
 }
 
 // MARK: Helpers

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -13,32 +13,28 @@ import Foundation
 infix operator => { associativity right precedence 150 }
 infix operator =>? { associativity right precedence 150 }
 
-public func => (lhs: AnyObject, rhs: String) throws -> AnyObject {
-    return try parse(lhs, path: [rhs], decode: { $0 })
+public func => (lhs: AnyObject, rhs: KeyPath) throws -> AnyObject {
+    return try parse(lhs, keyPath: rhs, decode: { $0 })
 }
 
-public func =>? (lhs: AnyObject, rhs: String) throws -> AnyObject? {
-    return try parseAndAcceptMissingKey(lhs, path: [rhs] , decode: { $0 })
+
+public func =>? (lhs: AnyObject, rhs: KeyPath) throws -> AnyObject? {
+    return try parseAndAcceptMissingKey(lhs, keyPath: rhs, decode: { $0 })
 }
 
-public func => (lhs: AnyObject, rhs: [String]) throws -> AnyObject {
-    return try parse(lhs, path: rhs, decode: { $0 })
-}
 
-public func =>? (lhs: AnyObject, rhs: [String]) throws -> AnyObject? {
-    return try parseAndAcceptMissingKey(lhs, path: rhs, decode: { $0 })
-}
 
 
 // MARK: - JSONPath
 
 /// Enables parsing nested objects e.g json => "a" => "b"
-public func => (lhs: String, rhs: String) -> [String] {
-    return [lhs, rhs]
+
+public func => (lhs: String, rhs: String) -> KeyPath {
+    return KeyPath(keys: [lhs, rhs])
 }
 
-public func => (lhs: String, rhs: [String]) -> [String] {
-    return [lhs] + rhs
+public func => (lhs: String, rhs: KeyPath) -> KeyPath {
+    return KeyPath(keys: [lhs] + rhs.keys)
 }
 
 // MARK: Helpers

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -30,11 +30,11 @@ public func =>? (lhs: AnyObject, rhs: KeyPath) throws -> AnyObject? {
 /// Enables parsing nested objects e.g json => "a" => "b"
 
 public func => (lhs: String, rhs: String) -> KeyPath {
-    return KeyPath(keys: [lhs, rhs])
+    return KeyPath([lhs, rhs])
 }
 
 public func => (lhs: String, rhs: KeyPath) -> KeyPath {
-    return KeyPath(keys: [lhs] + rhs.keys)
+    return KeyPath([lhs] + rhs.keys)
 }
 
 // MARK: Helpers

--- a/Sources/Overloads.swift
+++ b/Sources/Overloads.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 anviking. All rights reserved.
 //
 
-// 326 overloads were generated with the following return types:
+// 163 overloads were generated with the following return types:
 // [[A]?]?, [[A: B]?]?, [A?]?, [[A?]]?, [[[A]]]?, [[[A: B]]]?, [[A]]?, [[A: B?]]?, [[A: [B]]]?, [[A: [B: C]]]?, [[A: B]]?, [A]?, [A: [B]?]?, [A: [B: C]?]?, [A: B?]?, [A: [B?]]?, [A: [[B]]]?, [A: [[B: C]]]?, [A: [B]]?, [A: [B: C?]]?, [A: [B: [C]]]?, [A: [B: [C: D]]]?, [A: [B: C]]?, [A: B]?, A?, [[A?]?], [[[A]]?], [[[A: B]]?], [[A]?], [[A: B?]?], [[A: [B]]?], [[A: [B: C]]?], [[A: B]?], [A?], [[[A]?]], [[[A: B]?]], [[A?]], [[[A?]]], [[[[A]]]], [[[[A: B]]]], [[[A]]], [[[A: B?]]], [[[A: [B]]]], [[[A: [B: C]]]], [[[A: B]]], [[A]], [[A: [B]?]], [[A: [B: C]?]], [[A: B?]], [[A: [B?]]], [[A: [[B]]]], [[A: [[B: C]]]], [[A: [B]]], [[A: [B: C?]]], [[A: [B: [C]]]], [[A: [B: [C: D]]]], [[A: [B: C]]], [[A: B]], [A], [A: [B?]?], [A: [[B]]?], [A: [[B: C]]?], [A: [B]?], [A: [B: C?]?], [A: [B: [C]]?], [A: [B: [C: D]]?], [A: [B: C]?], [A: B?], [A: [[B]?]], [A: [[B: C]?]], [A: [B?]], [A: [[B?]]], [A: [[[B]]]], [A: [[[B: C]]]], [A: [[B]]], [A: [[B: C?]]], [A: [[B: [C]]]], [A: [[B: [C: D]]]], [A: [[B: C]]], [A: [B]], [A: [B: [C]?]], [A: [B: [C: D]?]], [A: [B: C?]], [A: [B: [C?]]], [A: [B: [[C]]]], [A: [B: [[C: D]]]], [A: [B: [C]]], [A: [B: [C: D?]]], [A: [B: [C: [D]]]], [A: [B: [C: [D: E]]]], [A: [B: [C: D]]], [A: [B: C]], [A: B], A
 
 /**
@@ -17,8 +17,8 @@
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A]?]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
 /**
@@ -29,8 +29,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B]?]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -41,8 +41,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]?]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A?]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(A.decode))))
 }
 
 /**
@@ -53,8 +53,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]?]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A?]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
 /**
@@ -65,8 +65,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(catchNull(A.decode))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
 /**
@@ -77,8 +77,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(catchNull(A.decode))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -89,8 +89,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(catchNull(A.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(A.decode))))
 }
 
 /**
@@ -101,8 +101,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(catchNull(A.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B?]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
 /**
@@ -113,8 +113,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
 /**
@@ -125,8 +125,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -137,8 +137,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]]? 
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
 /**
@@ -149,8 +149,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(A.decode)))
 }
 
 /**
@@ -161,8 +161,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeArray(A.decode))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B]?]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
 /**
@@ -173,8 +173,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeArray(A.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C]?]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -185,8 +185,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: B?]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
 /**
@@ -197,8 +197,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B?]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
 /**
@@ -209,8 +209,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
 /**
@@ -221,8 +221,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -233,8 +233,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
 /**
@@ -245,8 +245,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C?]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
 /**
@@ -257,8 +257,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
 /**
@@ -269,8 +269,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D]]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -281,8 +281,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A]? {
-    return try parse(json, path: [path], decode: catchNull(decodeArray(A.decode)))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C]]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
 /**
@@ -293,8 +293,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A]? {
-    return try parse(json, path: path, decode: catchNull(decodeArray(A.decode)))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: B]? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
 /**
@@ -305,8 +305,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A]? {
  - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]?]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> A? {
+    return try parse(json, keyPath: keyPath, decode: catchNull(A.decode))
 }
 
 /**
@@ -314,11 +314,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]?]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A?]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
 }
 
 /**
@@ -326,11 +325,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]?]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
 }
 
 /**
@@ -338,11 +336,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]?]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -350,11 +347,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B?]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(A.decode))))
 }
 
 /**
@@ -362,11 +358,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B?]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B?]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
 /**
@@ -374,11 +369,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
 /**
@@ -386,11 +380,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -398,11 +391,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
 /**
@@ -410,11 +402,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A?] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(A.decode)))
 }
 
 /**
@@ -422,11 +413,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
 /**
@@ -434,11 +424,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -446,11 +435,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(A.decode))))
 }
 
 /**
@@ -458,11 +446,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
 /**
@@ -470,11 +457,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[[A]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
 /**
@@ -482,11 +468,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[[A: B]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -494,11 +479,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(A.decode))))
 }
 
 /**
@@ -506,11 +490,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
 /**
@@ -518,11 +501,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: [B]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
 /**
@@ -530,11 +512,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: [B: C]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -542,11 +523,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
 /**
@@ -554,11 +534,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(A.decode)))
 }
 
 /**
@@ -566,11 +545,10 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B]? {
-    return try parse(json, path: [path], decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
 /**
@@ -578,11 +556,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B]? {
-    return try parse(json, path: path, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -590,11 +567,10 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> A? {
-    return try parse(json, path: [path], decode: catchNull(A.decode))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
 /**
@@ -602,11 +578,10 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> A? {
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Returns: nil if the pre-decoded object at `path` is `NSNull`.
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> A? {
-    return try parse(json, path: path, decode: catchNull(A.decode))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
 /**
@@ -616,8 +591,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> A? {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [[B]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
 /**
@@ -627,8 +602,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [[B: C]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -638,8 +613,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
 /**
@@ -649,8 +624,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
 /**
@@ -660,8 +635,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]?] 
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: [C]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
 /**
@@ -671,8 +646,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: [C: D]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -682,8 +657,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeArray(A.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
 /**
@@ -693,8 +668,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeArray(A.decode))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B]] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
 /**
@@ -704,8 +679,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A] {
+    return try parse(json, keyPath: keyPath, decode: decodeArray(A.decode))
 }
 
 /**
@@ -715,8 +690,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B?]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
 }
 
 /**
@@ -726,8 +701,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
 }
 
 /**
@@ -737,8 +712,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -748,8 +723,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
 }
 
 /**
@@ -759,8 +734,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C?]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
 /**
@@ -770,8 +745,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
 /**
@@ -781,8 +756,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D]]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -792,8 +767,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?] {
-    return try parse(json, path: [path], decode: decodeArray(catchNull(A.decode)))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C]?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
 /**
@@ -803,8 +778,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?] {
-    return try parse(json, path: path, decode: decodeArray(catchNull(A.decode)))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: B?] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
 }
 
 /**
@@ -814,8 +789,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A?] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]?]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
 }
 
 /**
@@ -825,8 +800,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]?]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]?]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -836,8 +811,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]?]] 
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]?]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
 }
 
 /**
@@ -847,8 +822,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]?]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
 }
 
 /**
@@ -858,8 +833,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(catchNull(A.decode))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[[B]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
 }
 
 /**
@@ -869,8 +844,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(catchNull(A.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[[B: C]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -880,8 +855,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A?]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
 }
 
 /**
@@ -891,8 +866,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A?]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A?]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
 /**
@@ -902,8 +877,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A?]]] 
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[[A]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: [C]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
 /**
@@ -913,8 +888,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[[A]]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[[A]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: [C: D]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -924,8 +899,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[[A]]]]
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[[A: B]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
 /**
@@ -935,8 +910,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[[A: B]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
 }
 
 /**
@@ -946,8 +921,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeArray(A.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
 }
 
 /**
@@ -957,8 +932,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeArray(A.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D]?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -968,8 +943,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B?]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C?]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
 }
 
 /**
@@ -979,8 +954,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B?]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
 }
 
 /**
@@ -990,8 +965,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [[C]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
 }
 
 /**
@@ -1001,8 +976,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [[C: D]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -1012,8 +987,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B: C]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
 }
 
 /**
@@ -1023,8 +998,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B: C]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D?]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
 }
 
 /**
@@ -1034,8 +1009,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path:
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: [D]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
 }
 
 /**
@@ -1045,8 +1020,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: [D: E]]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
 }
 
 /**
@@ -1056,8 +1031,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeArray(A.decode)))
+public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D]]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
 }
 
 /**
@@ -1067,8 +1042,8 @@ public func => <A: Decodable>(json: AnyObject, path: String)throws-> [[A]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]] {
-    return try parse(json, path: path, decode: decodeArray(decodeArray(A.decode)))
+public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C]] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
 }
 
 /**
@@ -1078,8 +1053,8 @@ public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]] {
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]?]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
+public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: B] {
+    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
 }
 
 /**
@@ -1089,8 +1064,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
  - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
 */
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]?]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
+public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> A {
+    return try parse(json, keyPath: keyPath, decode: A.decode)
 }
 
 /**
@@ -1098,1733 +1073,9 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thro
 
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]?]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]?]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B?]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B?]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B: C]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B: C]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C?]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C?]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C: D]]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C: D]]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]] {
-    return try parse(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]] {
-    return try parse(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> [A] {
-    return try parse(json, path: [path], decode: decodeArray(A.decode))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> [A] {
-    return try parse(json, path: path, decode: decodeArray(A.decode))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B?] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B?] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]?]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]?]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]?]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]?]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B?]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B?]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B: C]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B: C]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C?]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C?]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C: D]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C: D]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]?]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]?]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]?]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]?]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C?]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C?]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C: D]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C: D]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D?]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D?]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D: E]]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D: E]]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B] {
-    return try parse(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B] {
-    return try parse(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable>(json: AnyObject, path: String)throws-> A {
-    return try parse(json, path: [path], decode: A.decode)
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
- - Throws: `MissingKeyError` if `path` does not exist in `json`. `TypeMismatchError` or any other error thrown in the decode-closure
-*/
-public func => <A: Decodable>(json: AnyObject, path: [String])throws-> A {
-    return try parse(json, path: path, decode: A.decode)
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeArray(A.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeArray(A.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [A?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(catchNull(A.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [A?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(catchNull(A.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(catchNull(A.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(catchNull(A.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[[A]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[[A]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[[A: B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[[A: B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[[A]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeArray(A.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[[A]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeArray(A.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[[A: [B: C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[[A: [B: C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[[A: B]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[[A: B]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [[A]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeArray(A.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [[A]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeArray(A.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [[B: C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [[B: C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: [B]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: [C: D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: [C: D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [[A: [B: C]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [[A: [B: C]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [[A: B]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [[A: B]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> [A]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeArray(A.decode))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> [A]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeArray(A.decode))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
-*/
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
-}
-
-/**
- Retrieves the object at `path` from `json` and decodes it according to the return type
-
- - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
- - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A?]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
 }
 
 /**
@@ -2833,8 +1084,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
 }
 
 /**
@@ -2843,8 +1094,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -2853,8 +1104,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(A.decode))))
 }
 
 /**
@@ -2863,8 +1114,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B?]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
 /**
@@ -2873,8 +1124,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
 /**
@@ -2883,8 +1134,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -2893,8 +1144,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
 /**
@@ -2903,8 +1154,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(catchNull(A.decode)))
 }
 
 /**
@@ -2913,8 +1164,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
 }
 
 /**
@@ -2923,8 +1174,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -2933,8 +1184,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(A.decode))))
 }
 
 /**
@@ -2943,8 +1194,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
 }
 
 /**
@@ -2953,8 +1204,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[[A]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
 }
 
 /**
@@ -2963,8 +1214,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[[A: B]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
 }
 
 /**
@@ -2973,8 +1224,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B?]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(A.decode))))
 }
 
 /**
@@ -2983,8 +1234,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B?]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
 }
 
 /**
@@ -2993,8 +1244,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: [B]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
 }
 
 /**
@@ -3003,8 +1254,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: [B: C]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -3013,8 +1264,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[[A: B]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
 }
 
 /**
@@ -3023,8 +1274,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeArray(A.decode)))
 }
 
 /**
@@ -3033,8 +1284,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
 }
 
 /**
@@ -3043,8 +1294,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -3053,8 +1304,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
 }
 
 /**
@@ -3063,8 +1314,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
 }
 
 /**
@@ -3073,8 +1324,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [[B]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
 }
 
 /**
@@ -3083,8 +1334,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [[B: C]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -3093,8 +1344,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[[B: C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
 }
 
 /**
@@ -3103,8 +1354,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[[B: C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
 /**
@@ -3113,8 +1364,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [[B]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: [C]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
 /**
@@ -3123,8 +1374,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: [C: D]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -3133,8 +1384,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: [B: C]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
 /**
@@ -3143,8 +1394,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [[A: B]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
 }
 
 /**
@@ -3153,8 +1404,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeArray(A.decode))
 }
 
 /**
@@ -3163,8 +1414,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B?]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
 }
 
 /**
@@ -3173,8 +1424,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: [C: D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
 }
 
 /**
@@ -3183,8 +1434,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: [C: D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -3193,8 +1444,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [[B: C]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
 }
 
 /**
@@ -3203,8 +1454,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [[B: C]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C?]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
 /**
@@ -3213,8 +1464,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: [B]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
 /**
@@ -3223,8 +1474,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: [B]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D]]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -3233,8 +1484,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C]?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
 /**
@@ -3243,8 +1494,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: B?]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
 }
 
 /**
@@ -3253,8 +1504,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
 }
 
 /**
@@ -3263,8 +1514,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -3273,8 +1524,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C?]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
 }
 
 /**
@@ -3283,8 +1534,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C?]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
 }
 
 /**
@@ -3293,8 +1544,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[[B]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
 }
 
 /**
@@ -3303,8 +1554,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[[B: C]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
 }
 
 /**
@@ -3313,8 +1564,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
 }
 
 /**
@@ -3323,8 +1574,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
 }
 
 /**
@@ -3333,8 +1584,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [[C: D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: [C]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
 }
 
 /**
@@ -3343,8 +1594,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [[C: D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: [C: D]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -3353,8 +1604,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [[B: C]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
 }
 
 /**
@@ -3363,8 +1614,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
 }
 
 /**
@@ -3373,8 +1624,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D?]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
 }
 
 /**
@@ -3383,8 +1634,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D?]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D]?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -3393,8 +1644,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C?]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
 }
 
 /**
@@ -3403,8 +1654,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
 }
 
 /**
@@ -3413,8 +1664,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: [D: E]]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [[C]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
 }
 
 /**
@@ -3423,8 +1674,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: [D: E]]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [[C: D]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
 }
 
 /**
@@ -3433,8 +1684,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: String)throws-> [A: [B: [C: D]]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
 }
 
 /**
@@ -3443,8 +1694,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: [C: D]]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D?]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
 }
 
 /**
@@ -3453,8 +1704,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: String)throws-> [A: [B: C]]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: [D]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
 }
 
 /**
@@ -3463,8 +1714,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path: [String])throws-> [A: [B: C]]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: [D: E]]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
 }
 
 /**
@@ -3473,8 +1724,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, path
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throws-> [A: B]? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
+public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: [C: D]]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
 }
 
 /**
@@ -3483,8 +1734,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: String)throw
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])throws-> [A: B]? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
+public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: [B: C]]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
 }
 
 /**
@@ -3493,8 +1744,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, path: [String])thr
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> A? {
-    return try parseAndAcceptMissingKey(json, path: [path], decode: A.decode)
+public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> [A: B]? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
 }
 
 /**
@@ -3503,6 +1754,6 @@ public func =>? <A: Decodable>(json: AnyObject, path: String)throws-> A? {
  - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
  - parameter path: A null-separated key-path string. Can be generated with `"keyA" => "keyB"`
 */
-public func =>? <A: Decodable>(json: AnyObject, path: [String])throws-> A? {
-    return try parseAndAcceptMissingKey(json, path: path, decode: A.decode)
+public func =>? <A: Decodable>(json: AnyObject, keyPath: KeyPath)throws-> A? {
+    return try parseAndAcceptMissingKey(json, keyPath: keyPath, decode: A.decode)
 }

--- a/Tests/ArrayTests.swift
+++ b/Tests/ArrayTests.swift
@@ -17,7 +17,7 @@ class DecodableArrayTests: XCTestCase {
         let value: NSArray = ["value1", "value2", "value3"]
         let dictionary: NSDictionary = [key: value]
         // when
-        let result = try! dictionary => key as Array<String>
+        let result = try! dictionary => KeyPath(key) as Array<String>
         // then
         XCTAssertEqual(result, value)
     }
@@ -28,7 +28,7 @@ class DecodableArrayTests: XCTestCase {
         let value: NSArray = ["value1", "value2", NSNull(), "value3"]
         let dictionary: NSDictionary = [key: value]
         // when
-        let result = try! dictionary => key as [String?]
+        let result = try! dictionary => KeyPath(key) as [String?]
         // then
         XCTAssertEqual(result.count, 4)
         XCTAssertEqual(result[0], "value1")
@@ -44,7 +44,7 @@ class DecodableArrayTests: XCTestCase {
         let dictionary: NSDictionary = [key: value]
         // when
         do {
-            _ = try dictionary => key as [String?]
+            _ = try dictionary => KeyPath(key) as [String?]
             XCTFail("should throw")
         } catch is TypeMismatchError {
             // Yay
@@ -55,11 +55,10 @@ class DecodableArrayTests: XCTestCase {
     
     func testDecodeNestedDecodableArraySuccess() {
         // given
-        let key = "key"
         let value: NSArray = ["value1", "value2", "value3"]
-        let dictionary: NSDictionary = [key: [key: value]]
+        let dictionary: NSDictionary = ["key": ["key": value]]
         // when
-        let result = try! dictionary => key => key as Array<String>
+        let result = try! dictionary => "key" => "key" as Array<String>
         // then
         XCTAssertEqual(result, value)
     }
@@ -70,18 +69,17 @@ class DecodableArrayTests: XCTestCase {
         let value = ["value"]
         let dictionary: NSDictionary = [key: value]
         // when
-        let string = try! dictionary => key as [String]?
+        let string = try! dictionary => KeyPath(key) as [String]?
         // then
         XCTAssertEqual(string!, value)
     }
     
     func testDecodeAnyDecodableNestedOptionalArraySuccess() {
         // given
-        let key = "key"
         let value = ["value"]
-        let dictionary: NSDictionary = [key: [key: value]]
+        let dictionary: NSDictionary = ["key": ["key": value]]
         // when
-        let string = try! dictionary => key => key as [String]?
+        let string = try! dictionary => "key" => "key" as [String]?
         // then
         XCTAssertEqual(string!, value)
     }
@@ -91,7 +89,7 @@ class DecodableArrayTests: XCTestCase {
         let key = "key"
         let dictionary: NSDictionary = [key: NSNull()]
         // when
-        let string = try! dictionary => key as [String]?
+        let string = try! dictionary => KeyPath(key) as [String]?
         // then
         XCTAssertNil(string)
     }
@@ -102,7 +100,7 @@ class DecodableArrayTests: XCTestCase {
         let dictionary = NSDictionary()
         // when
         do {
-            _ = try dictionary => key as [String]?
+            _ = try dictionary => KeyPath(key) as [String]?
             XCTFail()
         } catch is MissingKeyError {
             
@@ -164,7 +162,7 @@ class DecodableArrayTests: XCTestCase {
         let value = [["login": "mradams"], ["id": 1, "login": "jenglish"]]
         let dictionary: NSDictionary = [key: value]
         // when
-        let array = try! [Owner].decode(dictionary => key, ignoreInvalidObjects: true)
+        let array = try! [Owner].decode(dictionary => KeyPath(key), ignoreInvalidObjects: true)
         // then
         XCTAssertEqual(array, [Owner(id: 1, login: "jenglish")])
     }

--- a/Tests/DecodableOperatorsTests.swift
+++ b/Tests/DecodableOperatorsTests.swift
@@ -81,11 +81,11 @@ class DecodableOperatorsTests: XCTestCase {
 
     func testDecodeNestedDictionaryCastingSuccess() {
         // given
-        let key = "key"
+
         let value: NSDictionary = ["aKey" : "value"]
-        let dictionary: NSDictionary = [key: [key: value]]
+        let dictionary: NSDictionary = ["key": ["key": value]]
         // when
-        let result = try! dictionary => key => key as! [String: String]
+        let result = try! dictionary => "key" => "key" as! [String: String]
         // then
         XCTAssertEqual(result, value)
     }
@@ -198,7 +198,7 @@ class DecodableOperatorsTests: XCTestCase {
     func testDecodeAnyDecodableThrowNoJsonObjectException() {
         // given
         let key = "key"
-        let noDictionary: AnyObject = "hello"
+        let noDictionary: NSString = "hello"
         // when
         do {
             _ = try noDictionary => KeyPath(key) as String
@@ -207,7 +207,7 @@ class DecodableOperatorsTests: XCTestCase {
             XCTAssertTrue(true)
             XCTAssertEqual(String(error.receivedType), "__NSCFString")
             XCTAssertEqual(error.formattedPath, "")
-            XCTAssertEqual(error.object as? NSString, (noDictionary as! NSString))
+            XCTAssertEqual(error.object as? NSString, (noDictionary))
         } catch let error {
             XCTFail("should not throw \(error)")
         }
@@ -235,7 +235,7 @@ class DecodableOperatorsTests: XCTestCase {
     func testDecodeAnyDecodableDictionaryThrowJSONNotObjectException() {
         // given
         let key = "key"
-        let noDictionary: AnyObject = "noDictionary"
+        let noDictionary: NSString = "noDictionary"
         // when
         do {
             _ = try noDictionary => KeyPath(key)
@@ -244,7 +244,7 @@ class DecodableOperatorsTests: XCTestCase {
             XCTAssertTrue(true)
             XCTAssertEqual(String(error.receivedType), "__NSCFString")
             XCTAssertEqual(error.formattedPath, "")
-            XCTAssertEqual(error.object as? NSString, (noDictionary as! NSString))
+            XCTAssertEqual(error.object as? NSString, noDictionary)
         } catch let error {
             XCTFail("should not throw \(error)")
         }

--- a/Tests/DecodableOperatorsTests.swift
+++ b/Tests/DecodableOperatorsTests.swift
@@ -19,7 +19,7 @@ class DecodableOperatorsTests: XCTestCase {
         let value = "value"
         let dictionary: NSDictionary = [key: value]
         // when
-        let string = try! dictionary => key as String
+        let string = try! dictionary => KeyPath(key) as String
         // then
         XCTAssertEqual(string, value)
     }
@@ -30,7 +30,7 @@ class DecodableOperatorsTests: XCTestCase {
         let value: NSDictionary = [key : "value"]
         let dictionary: NSDictionary = [key: value]
         // when
-        let result: NSDictionary = try! dictionary => key as! NSDictionary
+        let result: NSDictionary = try! dictionary => KeyPath(key) as! NSDictionary
         // then
         XCTAssertEqual(result, value)
     }
@@ -41,7 +41,7 @@ class DecodableOperatorsTests: XCTestCase {
         let value: NSDictionary = ["list": [1, 2, 3]]
         let dictionary: NSDictionary = [key: value]
         // when
-        let result: [String: [Int]] = try! dictionary => key
+        let result: [String: [Int]] = try! dictionary => KeyPath(key)
         // then
         XCTAssertEqual(result, value)
     }
@@ -50,22 +50,20 @@ class DecodableOperatorsTests: XCTestCase {
     
     func testDecodeNestedDictionarySuccess() {
         // given
-        let key = "key"
         let value: NSDictionary = ["aKey" : "value"]
-        let dictionary: NSDictionary = [key: [key: value]]
+        let dictionary: NSDictionary = ["key": ["key": value]]
         // when
-        let result = try! dictionary => key => key
+        let result = try! dictionary => "key" => "key"
         // then
         XCTAssertEqual(result as? NSDictionary, value)
     }
 
     func testDecodeNestedDictionaryOptionalSuccess() {
         // given
-        let key = "key"
         let value: NSDictionary = ["aKey" : "value"]
-        let dictionary: NSDictionary = [key: [key: value]]
+        let dictionary: NSDictionary = ["key": ["key": value]]
         // when
-        let result: [String: AnyObject]? = try! dictionary => key => key as! [String : AnyObject]
+        let result: [String: AnyObject]? = try! dictionary => "key" => "key" as! [String : AnyObject]
         // then
         XCTAssertEqual(result, value)
     }
@@ -98,7 +96,7 @@ class DecodableOperatorsTests: XCTestCase {
         let value = "value"
         let dictionary: NSDictionary = [key: value]
         // when
-        let string = try! dictionary => key as String?
+        let string = try! dictionary => KeyPath(key) as String?
         // then
         XCTAssertEqual(string!, value)
     }
@@ -108,7 +106,7 @@ class DecodableOperatorsTests: XCTestCase {
         let key = "key"
         let dictionary: NSDictionary = [key: NSNull()]
         // when
-        let string = try! dictionary => key as String?
+        let string = try! dictionary => KeyPath(key) as String?
         // then
         XCTAssertNil(string)
     }
@@ -119,7 +117,7 @@ class DecodableOperatorsTests: XCTestCase {
         let dictionary: NSDictionary = [key: 2]
         // when
         do {
-            let a = try dictionary => key as String?
+            let a = try dictionary => KeyPath(key) as String?
             print(a)
             XCTFail()
         } catch let error as TypeMismatchError {
@@ -200,16 +198,16 @@ class DecodableOperatorsTests: XCTestCase {
     func testDecodeAnyDecodableThrowNoJsonObjectException() {
         // given
         let key = "key"
-        let noDictionary: NSString = "hello"
+        let noDictionary: AnyObject = "hello"
         // when
         do {
-            _ = try noDictionary => key as String
+            _ = try noDictionary => KeyPath(key) as String
         } catch let error as TypeMismatchError where error.expectedType == NSDictionary.self {
             // then
             XCTAssertTrue(true)
             XCTAssertEqual(String(error.receivedType), "__NSCFString")
             XCTAssertEqual(error.formattedPath, "")
-            XCTAssertEqual(error.object as? NSString, noDictionary)
+            XCTAssertEqual(error.object as? NSString, (noDictionary as! NSString))
         } catch let error {
             XCTFail("should not throw \(error)")
         }
@@ -237,16 +235,16 @@ class DecodableOperatorsTests: XCTestCase {
     func testDecodeAnyDecodableDictionaryThrowJSONNotObjectException() {
         // given
         let key = "key"
-        let noDictionary: NSString = "noDictionary"
+        let noDictionary: AnyObject = "noDictionary"
         // when
         do {
-            _ = try noDictionary => key
+            _ = try noDictionary => KeyPath(key)
         } catch let error as TypeMismatchError where error.expectedType == NSDictionary.self {
             // then
             XCTAssertTrue(true)
             XCTAssertEqual(String(error.receivedType), "__NSCFString")
             XCTAssertEqual(error.formattedPath, "")
-            XCTAssertEqual(error.object as? NSString, noDictionary)
+            XCTAssertEqual(error.object as? NSString, (noDictionary as! NSString))
         } catch let error {
             XCTFail("should not throw \(error)")
         }
@@ -258,7 +256,7 @@ class DecodableOperatorsTests: XCTestCase {
         let dictionary: NSDictionary = [key: "value"]
         // when
         do {
-            _ = try dictionary => key
+            _ = try dictionary => KeyPath(key)
         } catch is TypeMismatchError {
             // then
             XCTAssertTrue(true)

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -164,7 +164,7 @@ class DecodableTests: XCTestCase {
         
         // when
         do {
-            _ = try parse(json, path: ["key"], decode: Repository.decode)
+            _ = try parse(json, keyPath: ["key"], decode: Repository.decode)
         } catch is MissingKeyError {
             XCTFail("it should not throw this exception")
         } catch let error as TypeMismatchError where error.expectedType == Int.self {

--- a/Tests/RawRepresentableDecodableTests.swift
+++ b/Tests/RawRepresentableDecodableTests.swift
@@ -24,7 +24,7 @@ class RawRepresentableDecodableTests: XCTestCase {
         let color = "Cyan"
         let json: NSDictionary = [key: color]
         // when
-        let cmykColor: CMYKColor = try! json => key
+        let cmykColor: CMYKColor = try! json => KeyPath(key)
         // then
         XCTAssertEqual(cmykColor, CMYKColor.Cyan)
     }
@@ -36,7 +36,7 @@ class RawRepresentableDecodableTests: XCTestCase {
         let json: NSDictionary = [key: color]
         // when
         do {
-            _ = try json => key as CMYKColor
+            _ = try json => KeyPath(key) as CMYKColor
             XCTFail()
         } catch let error as RawRepresentableInitializationError {
             // then
@@ -53,7 +53,7 @@ class RawRepresentableDecodableTests: XCTestCase {
         let json: NSDictionary = [key: color]
         // when
         do {
-            _ = try json => key as CMYKColor
+            _ = try json => KeyPath(key) as CMYKColor
             XCTFail()
         } catch let error as TypeMismatchError where error.expectedType == CMYKColor.RawValue.self {
             // then


### PR DESCRIPTION
Fixes #94 
From the documentation comment:
```swift
/// `KeyPath` represents the path to a specific node in a tree of nested dictionaries.
///
/// Can be created from string and array literals and can be joined by the `=>` operator.
/// ```
/// let a: KeyPath = "a"
/// let b: KeyPath = ["a", "b"]
/// let c: KeyPath = "a" => "b" => "c"
/// ```
```

`=>` Overloads now take a `KeyPath` instead of either `String` or `[String]`.

Since Strings are no longer used for constructing the KeyPath / previously `[String]` there can be no ambiguity between key joining overload and decoding overloads (`-> T`).

Obviously breaks ability to use strings (!= string literals) directly, which is mostly a problem in the unit tests which I had to alter, but I think it's kind of neat and logical.

In the future this could make accessing elements in arrays (like `["key"][2]`) and #77 easier to approach.