### PR TITLE
Rename closure functions

### DIFF
--- a/Generator/Generator.swift
+++ b/Generator/Generator.swift
@@ -108,11 +108,11 @@ indirect enum Decodable {
             //        case .AnyObject:
         //            return "{$0}"
         case Optional(let T):
-            return "catchNull(\(T.decodeClosure(provider)))"
+            return "optional(\(T.decodeClosure(provider)))"
         case Array(let T):
-            return "decodeArray(\(T.decodeClosure(provider)))"
+            return "array(\(T.decodeClosure(provider)))"
         case .Dictionary(let K, let T):
-            return "decodeDictionary(\(K.decodeClosure(provider)), elementDecodeClosure: \(T.decodeClosure(provider)))"
+            return "dictionary(key: \(K.decodeClosure(provider)), value: \(T.decodeClosure(provider)))"
         }
     }
     

--- a/Sources/Closures.swift
+++ b/Sources/Closures.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-func catchNull<T>(_ decodeClosure: (AnyObject) throws -> T) -> (AnyObject) throws -> T? {
+/// Takes a decode closure and returns one that returns nil if the json object is `NSNull`
+func optional<T>(_ decodeClosure: (AnyObject) throws -> T) -> (AnyObject) throws -> T? {
     return { json in
         if json is NSNull {
             return nil
@@ -18,15 +19,19 @@ func catchNull<T>(_ decodeClosure: (AnyObject) throws -> T) -> (AnyObject) throw
     }
 }
 
-/// Designed to be used with parse(json, path, decodeClosure) as the decodeClosure. Thats why it's curried and a "top-level" function instead of a function in an array extension. For everyday use, prefer using [T].decode(json) instead.
-public func decodeArray<T>(_ elementDecodeClosure: (AnyObject) throws -> T) -> (json: AnyObject) throws -> [T] {
+/// Create an array-decode-closure from an element decode closure
+///
+/// - returns: A closure that takes an `NSArray` and maps it using the element decode closure
+public func array<T>(_ elementDecodeClosure: (AnyObject) throws -> T) -> (json: AnyObject) throws -> [T] {
     return { json in
         return try NSArray.decode(json).map { try elementDecodeClosure($0) }
     }
 }
 
-/// Designed to be used with parse(json, path, decodeClosure) as the decodeClosure. Thats why it's curried. For everyday use, prefer using [K: V].decode(json) instead (declared in Decodable.swift).
-public func decodeDictionary<K,V>(_ keyDecodeClosure: (AnyObject) throws -> K, elementDecodeClosure: (AnyObject) throws -> V) -> (json: AnyObject) throws -> [K: V] {
+/// Create an dictionary-decode-closure from key- and value- decode closures
+///
+/// - returns: A closure that takes a `NSDictionary` and "maps" it using key and value decode closures 
+public func dictionary<K,V>(key keyDecodeClosure: (AnyObject) throws -> K, value elementDecodeClosure: (AnyObject) throws -> V) -> (json: AnyObject) throws -> [K: V] {
     return { json in
         var dict = [K: V]()
         for (key, value) in try NSDictionary.decode(json) {

--- a/Sources/Decodable.swift
+++ b/Sources/Decodable.swift
@@ -34,16 +34,16 @@ extension NSArray {
 
 extension Dictionary where Key: Decodable, Value: Decodable {
     public static func decode(_ j: AnyObject) throws -> Dictionary {
-        return try decodeDictionary(Key.decode, elementDecodeClosure: Value.decode)(json: j)
+        return try dictionary(key: Key.decode, value: Value.decode)(json: j)
     }
 }
 
 extension Array where Element: Decodable {
     public static func decode(_ j: AnyObject, ignoreInvalidObjects: Bool = false) throws -> [Element] {
         if ignoreInvalidObjects {
-            return try decodeArray { try? Element.decode($0) }(json: j).flatMap {$0}
+            return try array { try? Element.decode($0) }(json: j).flatMap {$0}
         } else {
-            return try decodeArray(Element.decode)(json: j)
+            return try array(Element.decode)(json: j)
         }
     }
 }

--- a/Sources/Overloads.swift
+++ b/Sources/Overloads.swift
@@ -17,7 +17,7 @@
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(array(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -28,7 +28,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(dictionary(key: A.decode, value: B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -39,7 +39,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(A.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(A.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -50,7 +50,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?]?
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(catchNull(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(optional(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -61,7 +61,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeArray(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(array(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -72,7 +72,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(dictionary(key: A.decode, value: B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -83,7 +83,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(A.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(A.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -94,7 +94,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -105,7 +105,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -116,7 +116,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -127,7 +127,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -138,7 +138,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(A.decode)))
+    return try parse(json, keyPath: keyPath, decode: optional(array(A.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -149,7 +149,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A]? 
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -160,7 +160,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -171,7 +171,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: B?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -182,7 +182,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -193,7 +193,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -204,7 +204,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -215,7 +215,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -226,7 +226,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -237,7 +237,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -248,7 +248,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -259,7 +259,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -270,7 +270,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: B]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: B.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -281,7 +281,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: `nil` if the object at `path` is `NSNull`
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(A.decode))
+    return try parse(json, keyPath: keyPath, decode: optional(A.decode))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -292,7 +292,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A? {
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(catchNull(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(array(optional(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -303,7 +303,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(decodeArray(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(array(array(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -314,7 +314,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(array(dictionary(key: A.decode, value: B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -325,7 +325,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeArray(A.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(array(A.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -336,7 +336,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B?]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(dictionary(key: A.decode, value: optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -347,7 +347,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(dictionary(key: A.decode, value: array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -358,7 +358,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -369,7 +369,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(optional(dictionary(key: A.decode, value: B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -380,7 +380,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(catchNull(A.decode)))
+    return try parse(json, keyPath: keyPath, decode: array(optional(A.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -391,7 +391,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?] 
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(decodeArray(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(optional(array(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -402,7 +402,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(optional(dictionary(key: A.decode, value: B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -413,7 +413,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(catchNull(A.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(array(optional(A.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -424,7 +424,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(catchNull(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(array(optional(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -435,7 +435,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A?
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(decodeArray(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(array(array(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -446,7 +446,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A: B]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(array(dictionary(key: A.decode, value: B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -457,7 +457,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeArray(A.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(array(array(A.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -468,7 +468,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(dictionary(key: A.decode, value: optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -479,7 +479,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: [B]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(dictionary(key: A.decode, value: array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -490,7 +490,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: [B: C]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -501,7 +501,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(array(dictionary(key: A.decode, value: B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -512,7 +512,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeArray(A.decode)))
+    return try parse(json, keyPath: keyPath, decode: array(array(A.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -523,7 +523,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: optional(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -534,7 +534,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -545,7 +545,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: optional(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -556,7 +556,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: array(optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -567,7 +567,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [[B]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: array(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -578,7 +578,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [[B: C]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -589,7 +589,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: array(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -600,7 +600,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -611,7 +611,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: [C]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -622,7 +622,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: [C: D]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -633,7 +633,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -644,7 +644,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B]] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
+    return try parse(json, keyPath: keyPath, decode: array(dictionary(key: A.decode, value: B.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -655,7 +655,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A] {
-    return try parse(json, keyPath: keyPath, decode: decodeArray(A.decode))
+    return try parse(json, keyPath: keyPath, decode: array(A.decode))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -666,7 +666,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A] {
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B?]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(array(optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -677,7 +677,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(array(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -688,7 +688,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(array(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -699,7 +699,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(array(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -710,7 +710,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C?]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: optional(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -721,7 +721,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: array(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -732,7 +732,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D]]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -743,7 +743,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C]?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: C.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -754,7 +754,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: B?] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: optional(B.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -765,7 +765,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(optional(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -776,7 +776,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(optional(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -787,7 +787,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(optional(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -798,7 +798,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(array(optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -809,7 +809,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[[B]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(array(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -820,7 +820,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[[B: C]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(array(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -831,7 +831,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(array(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -842,7 +842,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: optional(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -853,7 +853,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: [C]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: array(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -864,7 +864,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: [C: D]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -875,7 +875,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: C.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -886,7 +886,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: array(B.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -897,7 +897,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(array(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -908,7 +908,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D]?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(dictionary(key: C.decode, value: D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -919,7 +919,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C?]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(C.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -930,7 +930,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(optional(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -941,7 +941,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [[C]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(array(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -952,7 +952,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [[C: D]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(dictionary(key: C.decode, value: D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -963,7 +963,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(C.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -974,7 +974,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D?]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: optional(D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -985,7 +985,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: [D]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: array(D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -996,7 +996,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: [D: E]]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode)))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: dictionary(key: D.decode, value: E.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1007,7 +1007,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decod
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D]]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1018,7 +1018,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C]] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1029,7 +1029,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 /// - returns: something
 ///
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: B] {
-    return try parse(json, keyPath: keyPath, decode: decodeDictionary(A.decode, elementDecodeClosure: B.decode))
+    return try parse(json, keyPath: keyPath, decode: dictionary(key: A.decode, value: B.decode))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1051,7 +1051,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A?]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeArray(catchNull(A.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(array(optional(A.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1062,7 +1062,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeArray(decodeArray(A.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(array(array(A.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1073,7 +1073,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(array(dictionary(key: A.decode, value: B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1084,7 +1084,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(array(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1095,7 +1095,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B?]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(dictionary(key: A.decode, value: optional(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1106,7 +1106,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(dictionary(key: A.decode, value: array(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1117,7 +1117,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1128,7 +1128,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(dictionary(key: A.decode, value: B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1139,7 +1139,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(A.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(optional(A.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1150,7 +1150,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(catchNull(decodeArray(A.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(optional(array(A.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1161,7 +1161,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(optional(dictionary(key: A.decode, value: B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1172,7 +1172,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(catchNull(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(optional(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1183,7 +1183,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeArray(catchNull(A.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(array(optional(A.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1194,7 +1194,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[[A]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeArray(decodeArray(A.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(array(array(A.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1205,7 +1205,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[[A: B]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(array(dictionary(key: A.decode, value: B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1216,7 +1216,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeArray(A.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(array(A.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1227,7 +1227,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(dictionary(key: A.decode, value: optional(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1238,7 +1238,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: [B]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(dictionary(key: A.decode, value: array(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1249,7 +1249,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: [B: C]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1260,7 +1260,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(dictionary(key: A.decode, value: B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1271,7 +1271,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeArray(A.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(array(A.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1282,7 +1282,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: optional(array(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1293,7 +1293,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1304,7 +1304,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1315,7 +1315,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: array(optional(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1326,7 +1326,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [[B]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: array(array(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1337,7 +1337,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [[B: C]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1348,7 +1348,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1359,7 +1359,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1370,7 +1370,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: [C]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1381,7 +1381,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: [C: D]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1392,7 +1392,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1403,7 +1403,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(decodeDictionary(A.decode, elementDecodeClosure: B.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(array(dictionary(key: A.decode, value: B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1414,7 +1414,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(A.decode)))
+    return try parse(json, keyPath: keyPath, decode: optional(array(A.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1425,7 +1425,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B?]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(catchNull(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(array(optional(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1436,7 +1436,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeArray(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(array(array(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1447,7 +1447,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(array(dictionary(key: B.decode, value: C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1458,7 +1458,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1469,7 +1469,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C?]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: optional(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1480,7 +1480,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: array(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1491,7 +1491,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D]]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1502,7 +1502,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C]?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1513,7 +1513,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: B?]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: catchNull(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: optional(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1524,7 +1524,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeArray(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(optional(array(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1535,7 +1535,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(optional(dictionary(key: B.decode, value: C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1546,7 +1546,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(catchNull(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(optional(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1557,7 +1557,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(catchNull(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(array(optional(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1568,7 +1568,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[[B]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeArray(B.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(array(array(B.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1579,7 +1579,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[[B: C]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(array(dictionary(key: B.decode, value: C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1590,7 +1590,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeArray(B.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(array(B.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1601,7 +1601,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: optional(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1612,7 +1612,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: [C]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: array(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1623,7 +1623,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: [C: D]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1634,7 +1634,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(decodeDictionary(B.decode, elementDecodeClosure: C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(dictionary(key: B.decode, value: C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1645,7 +1645,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeArray(B.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: array(B.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1656,7 +1656,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeArray(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(array(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1667,7 +1667,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D]?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(decodeDictionary(C.decode, elementDecodeClosure: D.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(dictionary(key: C.decode, value: D.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1678,7 +1678,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C?]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: catchNull(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: optional(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1689,7 +1689,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(catchNull(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(optional(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1700,7 +1700,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [[C]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeArray(C.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(array(C.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1711,7 +1711,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [[C: D]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(decodeDictionary(C.decode, elementDecodeClosure: D.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(dictionary(key: C.decode, value: D.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1722,7 +1722,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeArray(C.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: array(C.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1733,7 +1733,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D?]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: catchNull(D.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: optional(D.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1744,7 +1744,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: [D]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeArray(D.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: array(D.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1755,7 +1755,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: [D: E]]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: decodeDictionary(D.decode, elementDecodeClosure: E.decode))))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: dictionary(key: D.decode, value: E.decode))))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1766,7 +1766,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D]]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: decodeDictionary(C.decode, elementDecodeClosure: D.decode)))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: dictionary(key: C.decode, value: D.decode)))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1777,7 +1777,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C]]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: decodeDictionary(B.decode, elementDecodeClosure: C.decode))))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: dictionary(key: B.decode, value: C.decode))))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1788,7 +1788,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: B]? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(decodeDictionary(A.decode, elementDecodeClosure: B.decode)))
+    return try parse(json, keyPath: keyPath, decode: optional(dictionary(key: A.decode, value: B.decode)))
 }
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1799,5 +1799,5 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> A? {
-    return try parse(json, keyPath: keyPath, decode: catchNull(A.decode))
+    return try parse(json, keyPath: keyPath, decode: optional(A.decode))
 }


### PR DESCRIPTION
## Changes
`decodeArray(_:)` -> `array(_:)`
`catchNull(_:)` -> `optional(_:)`
`decodeDictionary(_:elementDecodeClosure:)` -> `dictionary(key: element:)`

## Motivation
The main motivation for this is to encourage use of the functions that take and return decode functions, thereby encouraging not conforming to the `Decodable` protocol.

The places where they are intended to be used are for `decode` parameters, which is also how they are used internally in each overload. Since the parameter already is called `decode`, stripping the word from each call makes it more readable:
```diff
-return try parse(json, keyPath: keyPath, decode: catchNull(decodeArray(catchNull(decodeArray(A.decode)))))
+return try parse(json, keyPath: keyPath, decode: optional(array(optional(array(A.decode)))))
```

Furthermore `catchNull` is a misleading name that incorrectly implies that errors are caught (they did before though, and it was incorrect). Instead it works by checking if the object is `NSNull`.

`decodeDictionary`s only had a label for the value/element decode closures, that also was very long.

These new names could pollute the namespace since they are lowerspace variants of Swift types. However the files that `import Decodable` should be mostly model and networking code that is already very separated.

## Alternatives
- `optional(of: array(of: T.decode))`?
- Keep decode prefix
- ?

## Why did I write this?
To document changes, motivations and give an opportunity for objections, even if I'm probably merging this right away.
