### PR TITLE
Experiment: Fix(?) keypaths and add `decode` overloads on `NSDictionary` 

### DIFF
--- a/Generator/Generator.swift
+++ b/Generator/Generator.swift
@@ -202,7 +202,7 @@ indirect enum Decodable {
         
         overloads.append(
             "extension NSDictionary {\n" +
-                "    public func decode \(generics)(_ keyPath: \(keyType)...) throws -> \(returnType) {\n" +
+                "    public final func decode \(generics)(_ keyPath: \(keyType)...) throws -> \(returnType) {\n" +
                 "        return try parse(self, keyPath: \(keyPathType)(keyPath)\(keyPathModifier), decoder: \(decodeClosure(provider)))\n" +
                 "    }\n" +
             "}"

--- a/Generator/Generator.swift
+++ b/Generator/Generator.swift
@@ -204,7 +204,7 @@ indirect enum Decodable {
             "extension NSDictionary {\n" +
                 "    public func decode \(generics)(_ keyPath: \(keyType)...) throws -> \(returnType) {\n" +
                 "        return try parse(self, keyPath: \(keyPathType)(keyPath)\(keyPathModifier), decoder: \(decodeClosure(provider)))\n" +
-                "    }" +
+                "    }\n" +
             "}"
         )
         

--- a/Generator/Templates/Header.swift
+++ b/Generator/Templates/Header.swift
@@ -8,3 +8,5 @@
 
 // {count} overloads were generated with the following return types:
 // {overloads}
+
+import Foundation

--- a/Sources/Decodable.swift
+++ b/Sources/Decodable.swift
@@ -37,17 +37,6 @@ extension Array where Element: Decodable {
     }
 }
 
-extension NSDictionary {
-    public func decode<T: Decodable>(_ keyPath: String...) throws -> T {
-        return try parse(self, keyPath: KeyPath(keyPath), decoder: T.decode)
-    }
-    
-    public func decode<T: Decodable>(_ keyPath: OptionalKey...) throws -> T? {
-        return try parse(self, keyPath: OptionalKeyPath(keys: keyPath), decoder: T.decode)
-    }
-}
-
-
 // MARK: Helpers
 
 /// Attempt to decode one of multiple objects in order until: A: we get a positive match, B: we throw an exception if the last object does not decode

--- a/Sources/Decodable.swift
+++ b/Sources/Decodable.swift
@@ -37,7 +37,15 @@ extension Array where Element: Decodable {
     }
 }
 
-
+extension NSDictionary {
+    public func decode<T: Decodable>(_ keyPath: String...) throws -> T {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: T.decode)
+    }
+    
+    public func decode<T: Decodable>(_ keyPath: OptionalKey...) throws -> T? {
+        return try parse(self, keyPath: OptionalKeyPath(keys: keyPath), decoder: T.decode)
+    }
+}
 
 
 // MARK: Helpers

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -32,18 +32,18 @@ public func => (lhs: KeyPath, rhs: KeyPath) -> KeyPath {
 }
 
 public func => (lhs: OptionalKeyPath, rhs: OptionalKeyPath) -> OptionalKeyPath {
-    return OptionalKeyPath(keys: lhs.keys + rhs.markingFirst(required: true).keys)
+    return OptionalKeyPath(lhs.keys + rhs.markingFirst(required: true).keys)
 }
 
 public func =>? (lhs: OptionalKeyPath, rhs: OptionalKeyPath) -> OptionalKeyPath {
-    return OptionalKeyPath(keys: lhs.keys + rhs.keys)
+    return OptionalKeyPath(lhs.keys + rhs.keys)
 }
 
 public func => (lhs: OptionalKeyPath, rhs: KeyPath) -> OptionalKeyPath {
-    return OptionalKeyPath(keys: lhs.keys + rhs.keys.map { OptionalKey(key: $0, isRequired: true) })
+    return OptionalKeyPath(lhs.keys + rhs.keys.map { OptionalKey(key: $0, isRequired: true) })
 }
 
 
 public func =>? (lhs: KeyPath, rhs: OptionalKeyPath) -> OptionalKeyPath {
-    return OptionalKeyPath(keys: lhs.keys.map { OptionalKey(key: $0, isRequired: true) } + rhs.keys  )
+    return OptionalKeyPath(lhs.keys.map { OptionalKey(key: $0, isRequired: true) } + rhs.keys  )
 }

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -36,7 +36,7 @@ public func => (lhs: OptionalKeyPath, rhs: OptionalKeyPath) -> OptionalKeyPath {
 }
 
 public func =>? (lhs: OptionalKeyPath, rhs: OptionalKeyPath) -> OptionalKeyPath {
-    return OptionalKeyPath(lhs.keys + rhs.keys)
+    return OptionalKeyPath(lhs.keys + rhs.markingFirst(required: false).keys)
 }
 
 public func => (lhs: OptionalKeyPath, rhs: KeyPath) -> OptionalKeyPath {
@@ -45,5 +45,5 @@ public func => (lhs: OptionalKeyPath, rhs: KeyPath) -> OptionalKeyPath {
 
 
 public func =>? (lhs: KeyPath, rhs: OptionalKeyPath) -> OptionalKeyPath {
-    return OptionalKeyPath(lhs.keys.map { OptionalKey(key: $0, isRequired: true) } + rhs.keys  )
+    return OptionalKeyPath(lhs.keys.map { OptionalKey(key: $0, isRequired: true) } + rhs.markingFirst(required: false).keys  )
 }

--- a/Sources/OptionalKeyPath.swift
+++ b/Sources/OptionalKeyPath.swift
@@ -16,6 +16,16 @@ import Foundation
 public struct OptionalKey {
     var key: String
     var isRequired: Bool
+    
+    public init(key: String, isRequired: Bool) {
+        self.key = key
+        self.isRequired = isRequired
+    }
+    
+    public init(_ key: String) {
+        self.key = key
+        self.isRequired = false
+    }
 }
 
 extension OptionalKey: CustomStringConvertible {
@@ -25,22 +35,22 @@ extension OptionalKey: CustomStringConvertible {
 }
 
 extension String {
-    var optional: OptionalKey {
+    public var optional: OptionalKey {
         return OptionalKey(key: self, isRequired: false)
     }
 }
 
 extension OptionalKey: StringLiteralConvertible {
     public init(stringLiteral value: String) {
-        self.init(key: value, isRequired: false)
+        self.init(key: value, isRequired: true)
     }
     
     public init(extendedGraphemeClusterLiteral value: String) {
-        self.init(key: value, isRequired: false)
+        self.init(key: value, isRequired: true)
     }
     
     public init(unicodeScalarLiteral value: String) {
-        self.init(key: value, isRequired: false)
+        self.init(key: value, isRequired: true)
     }
 }
 
@@ -66,6 +76,8 @@ extension OptionalKey: StringLiteralConvertible {
 
 public struct OptionalKeyPath {
     var keys: [OptionalKey]
+    
+    
     mutating func markFirst(required: Bool) {
         if var first = keys.first {
             first.isRequired = required

--- a/Sources/OptionalKeyPath.swift
+++ b/Sources/OptionalKeyPath.swift
@@ -100,15 +100,15 @@ public struct OptionalKeyPath {
 
 extension OptionalKeyPath: StringLiteralConvertible {
     public init(stringLiteral value: String) {
-        self.keys = [OptionalKey(key: value, isRequired: false)]
+        self.keys = [OptionalKey(key: value, isRequired: true)]
     }
     
     public init(extendedGraphemeClusterLiteral value: String) {
-        self.keys = [OptionalKey(key: value, isRequired: false)]
+        self.keys = [OptionalKey(key: value, isRequired: true)]
     }
     
     public init(unicodeScalarLiteral value: String) {
-        self.keys = [OptionalKey(key: value, isRequired: false)]
+        self.keys = [OptionalKey(key: value, isRequired: true)]
     }
 }
 

--- a/Sources/OptionalKeyPath.swift
+++ b/Sources/OptionalKeyPath.swift
@@ -24,6 +24,26 @@ extension OptionalKey: CustomStringConvertible {
     }
 }
 
+extension String {
+    var optional: OptionalKey {
+        return OptionalKey(key: self, isRequired: false)
+    }
+}
+
+extension OptionalKey: StringLiteralConvertible {
+    public init(stringLiteral value: String) {
+        self.init(key: value, isRequired: false)
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(key: value, isRequired: false)
+    }
+    
+    public init(unicodeScalarLiteral value: String) {
+        self.init(key: value, isRequired: false)
+    }
+}
+
 /// `OptionalKeyPath` represents the path to a specific node in a tree of nested dictionaries.
 ///
 /// Can be created from string and array literals and can be joined by the `=>?` operator.
@@ -78,8 +98,8 @@ extension OptionalKeyPath: StringLiteralConvertible {
 }
 
 extension OptionalKeyPath: ArrayLiteralConvertible {
-    public init(arrayLiteral elements: String...) {
-        self.keys = elements.map { OptionalKey(key: $0, isRequired: false) }
+    public init(arrayLiteral elements: OptionalKey...) {
+        self.keys = elements
     }
 }
 

--- a/Sources/OptionalKeyPath.swift
+++ b/Sources/OptionalKeyPath.swift
@@ -77,6 +77,9 @@ extension OptionalKey: StringLiteralConvertible {
 public struct OptionalKeyPath {
     var keys: [OptionalKey]
     
+    public init (_ keys: [OptionalKey]) {
+        self.keys = keys
+    }
     
     mutating func markFirst(required: Bool) {
         if var first = keys.first {

--- a/Sources/Overloads.swift
+++ b/Sources/Overloads.swift
@@ -9,10 +9,13 @@
 // 326 overloads were generated with the following return types:
 // [[A]?]?, [[A: B]?]?, [A?]?, [[A?]]?, [[[A]]]?, [[[A: B]]]?, [[A]]?, [[A: B?]]?, [[A: [B]]]?, [[A: [B: C]]]?, [[A: B]]?, [A]?, [A: [B]?]?, [A: [B: C]?]?, [A: B?]?, [A: [B?]]?, [A: [[B]]]?, [A: [[B: C]]]?, [A: [B]]?, [A: [B: C?]]?, [A: [B: [C]]]?, [A: [B: [C: D]]]?, [A: [B: C]]?, [A: B]?, A?, [[A?]?], [[[A]]?], [[[A: B]]?], [[A]?], [[A: B?]?], [[A: [B]]?], [[A: [B: C]]?], [[A: B]?], [A?], [[[A]?]], [[[A: B]?]], [[A?]], [[[A?]]], [[[[A]]]], [[[[A: B]]]], [[[A]]], [[[A: B?]]], [[[A: [B]]]], [[[A: [B: C]]]], [[[A: B]]], [[A]], [[A: [B]?]], [[A: [B: C]?]], [[A: B?]], [[A: [B?]]], [[A: [[B]]]], [[A: [[B: C]]]], [[A: [B]]], [[A: [B: C?]]], [[A: [B: [C]]]], [[A: [B: [C: D]]]], [[A: [B: C]]], [[A: B]], [A], [A: [B?]?], [A: [[B]]?], [A: [[B: C]]?], [A: [B]?], [A: [B: C?]?], [A: [B: [C]]?], [A: [B: [C: D]]?], [A: [B: C]?], [A: B?], [A: [[B]?]], [A: [[B: C]?]], [A: [B?]], [A: [[B?]]], [A: [[[B]]]], [A: [[[B: C]]]], [A: [[B]]], [A: [[B: C?]]], [A: [[B: [C]]]], [A: [[B: [C: D]]]], [A: [[B: C]]], [A: [B]], [A: [B: [C]?]], [A: [B: [C: D]?]], [A: [B: C?]], [A: [B: [C?]]], [A: [B: [[C]]]], [A: [B: [[C: D]]]], [A: [B: [C]]], [A: [B: [C: D?]]], [A: [B: [C: [D]]]], [A: [B: [C: [D: E]]]], [A: [B: [C: D]]], [A: [B: C]], [A: B], A
 
+import Foundation
+
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -28,7 +31,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -44,7 +48,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [A?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -60,7 +65,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?]?
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -76,7 +82,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -92,7 +99,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -108,7 +116,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -124,7 +133,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -140,7 +150,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -156,7 +167,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -172,7 +184,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -188,7 +201,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [A]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(A.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -204,7 +218,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A]? 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -220,7 +235,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -236,7 +252,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -252,7 +269,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -268,7 +286,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -284,7 +303,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -300,7 +320,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -316,7 +337,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -332,7 +354,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -348,7 +371,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -364,7 +388,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -380,7 +405,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -396,7 +422,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> A? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(A.decode))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -412,7 +439,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A? {
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -428,7 +456,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -444,7 +473,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -460,7 +490,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(A.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -476,7 +507,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -492,7 +524,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -508,7 +541,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -524,7 +558,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -540,7 +575,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [A?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(A.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -556,7 +592,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?] 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -572,7 +609,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -588,7 +626,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(A.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -604,7 +643,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -620,7 +660,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A?
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[[A]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -636,7 +677,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[[A: B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -652,7 +694,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(A.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -668,7 +711,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -684,7 +728,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: [B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -700,7 +745,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[[A: [B: C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -716,7 +762,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -732,7 +779,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(A.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -748,7 +796,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -764,7 +813,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -780,7 +830,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -796,7 +847,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -812,7 +864,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [[B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -828,7 +881,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [[B: C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -844,7 +898,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -860,7 +915,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -876,7 +932,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -892,7 +949,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C: D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -908,7 +966,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -924,7 +983,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -940,7 +1000,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> [A] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(A.decode))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -956,7 +1017,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A] {
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -972,7 +1034,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -988,7 +1051,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1004,7 +1068,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1020,7 +1085,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1036,7 +1102,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1052,7 +1119,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1068,7 +1136,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1084,7 +1153,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1100,7 +1170,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1116,7 +1187,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1132,7 +1204,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1148,7 +1221,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1164,7 +1238,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[[B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1180,7 +1255,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[[B: C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1196,7 +1272,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1212,7 +1289,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1228,7 +1306,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1244,7 +1323,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C: D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1260,7 +1340,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1276,7 +1357,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1292,7 +1374,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1308,7 +1391,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1324,7 +1408,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1340,7 +1425,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1356,7 +1442,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1372,7 +1459,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C: D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1388,7 +1476,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1404,7 +1493,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1420,7 +1510,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1436,7 +1527,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D: E]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1452,7 +1544,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decod
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1468,7 +1561,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1484,7 +1578,8 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: B.decode))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1500,7 +1595,8 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: String...) throws -> A {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: A.decode)
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1516,7 +1612,8 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A {
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1532,7 +1629,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1548,7 +1646,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1564,7 +1663,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1580,7 +1680,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1596,7 +1697,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1612,7 +1714,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1628,7 +1731,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1644,7 +1748,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1660,7 +1765,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1676,7 +1782,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1692,7 +1799,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1708,7 +1816,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1724,7 +1833,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1740,7 +1850,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A: B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1756,7 +1867,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1772,7 +1884,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1788,7 +1901,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1804,7 +1918,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B: C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1820,7 +1935,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1836,7 +1952,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1852,7 +1969,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1868,7 +1986,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1884,7 +2003,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1900,7 +2020,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1916,7 +2037,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1932,7 +2054,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B: C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1948,7 +2071,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1964,7 +2088,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1980,7 +2105,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1996,7 +2122,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C: D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2012,7 +2139,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2028,7 +2156,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2044,7 +2173,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(A.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2060,7 +2190,8 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2076,7 +2207,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2092,7 +2224,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2108,7 +2241,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2124,7 +2258,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2140,7 +2275,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2156,7 +2292,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2172,7 +2309,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2188,7 +2326,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2204,7 +2343,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2220,7 +2360,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2236,7 +2377,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2252,7 +2394,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2268,7 +2411,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2284,7 +2428,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B: C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2300,7 +2445,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2316,7 +2462,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2332,7 +2479,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2348,7 +2496,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C: D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2364,7 +2513,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2380,7 +2530,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2396,7 +2547,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2412,7 +2564,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2428,7 +2581,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2444,7 +2598,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2460,7 +2615,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2476,7 +2632,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C: D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2492,7 +2649,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2508,7 +2666,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2524,7 +2683,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2540,7 +2700,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D: E]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2556,7 +2717,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2572,7 +2734,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2588,7 +2751,8 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -2604,7 +2768,8 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> A? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(A.decode))
-    }}
+    }
+}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 

--- a/Sources/Overloads.swift
+++ b/Sources/Overloads.swift
@@ -1515,7 +1515,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A {
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1526,12 +1526,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A?]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1542,12 +1542,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1558,12 +1558,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1574,12 +1574,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1590,12 +1590,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B?]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1606,12 +1606,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1622,12 +1622,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1638,12 +1638,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1654,12 +1654,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1670,12 +1670,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1686,12 +1686,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1702,12 +1702,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1718,12 +1718,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1734,12 +1734,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[[A]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A: B]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1750,12 +1750,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[[A: B]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1766,12 +1766,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1782,12 +1782,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1798,12 +1798,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: [B]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B: C]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1814,12 +1814,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: [B: C]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1830,12 +1830,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1846,12 +1846,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1862,12 +1862,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1878,12 +1878,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1894,12 +1894,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1910,12 +1910,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1926,12 +1926,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [[B]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B: C]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1942,12 +1942,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [[B: C]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1958,12 +1958,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1974,12 +1974,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -1990,12 +1990,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: [C]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C: D]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2006,12 +2006,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: [C: D]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2022,12 +2022,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2038,12 +2038,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(A.decode)))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(A.decode)))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2054,12 +2054,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(A.decode)))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Array.decoder(A.decode)))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2070,12 +2070,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B?]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2086,12 +2086,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2102,12 +2102,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2118,12 +2118,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2134,12 +2134,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C?]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2150,12 +2150,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2166,12 +2166,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D]]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2182,12 +2182,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C]?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B?]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2198,12 +2198,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: B?]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2214,12 +2214,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2230,12 +2230,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2246,12 +2246,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2262,12 +2262,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2278,12 +2278,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[[B]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B: C]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2294,12 +2294,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[[B: C]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2310,12 +2310,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2326,12 +2326,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2342,12 +2342,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: [C]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C: D]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2358,12 +2358,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: [C: D]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2374,12 +2374,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2390,12 +2390,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2406,12 +2406,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2422,12 +2422,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D]?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2438,12 +2438,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C?]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2454,12 +2454,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2470,12 +2470,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [[C]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C: D]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2486,12 +2486,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [[C: D]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2502,12 +2502,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D?]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2518,12 +2518,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D?]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2534,12 +2534,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: [D]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D: E]]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2550,12 +2550,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: [D: E]]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2566,12 +2566,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D]]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2582,12 +2582,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C]]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B]? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2598,12 +2598,12 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: B]? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
 }
 
 extension NSDictionary {
     public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> A? {
-        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(A.decode))
+        return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(A.decode))
     }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
@@ -2614,5 +2614,5 @@ extension NSDictionary {
 /// - returns: `nil` if the object at `path` is `NSNull` or if any optional key is missing.
 ///
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> A? {
-    return try parse(json, keyPath: keyPath, decoder: Optional.decoder(A.decode))
+    return try parse(json, keyPath: keyPath.markingFirst(required: false), decoder: Optional.decoder(A.decode))
 }

--- a/Sources/Overloads.swift
+++ b/Sources/Overloads.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?]? {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
     }
 }
@@ -29,7 +29,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }
 }
@@ -46,7 +46,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A?]? {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [A?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
     }
 }
@@ -63,7 +63,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?]?
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]]? {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
     }
 }
@@ -80,7 +80,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]]? {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
     }
 }
@@ -97,7 +97,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }
 }
@@ -114,7 +114,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]]? {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
     }
 }
@@ -131,7 +131,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
     }
 }
@@ -148,7 +148,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
     }
 }
@@ -165,7 +165,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -182,7 +182,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
     }
 }
@@ -199,7 +199,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A]? {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [A]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(A.decode)))
     }
 }
@@ -216,7 +216,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A]? 
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -233,7 +233,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -250,7 +250,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
     }
 }
@@ -267,7 +267,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
     }
 }
@@ -284,7 +284,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -301,7 +301,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -318,7 +318,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
     }
 }
@@ -335,7 +335,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
     }
 }
@@ -352,7 +352,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
     }
 }
@@ -369,7 +369,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
     }
 }
@@ -386,7 +386,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
     }
 }
@@ -403,7 +403,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B]? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
     }
 }
@@ -420,7 +420,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> A? {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> A? {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(A.decode))
     }
 }
@@ -437,7 +437,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A? {
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]?] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode)))))
     }
 }
@@ -454,7 +454,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]?] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode)))))
     }
 }
@@ -471,7 +471,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }
 }
@@ -488,7 +488,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(A.decode))))
     }
 }
@@ -505,7 +505,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
     }
 }
@@ -522,7 +522,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
     }
 }
@@ -539,7 +539,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]?] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -556,7 +556,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
     }
 }
@@ -573,7 +573,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A?] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [A?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(A.decode)))
     }
 }
@@ -590,7 +590,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?] 
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]?]] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
     }
 }
@@ -607,7 +607,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]?]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }
 }
@@ -624,7 +624,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(A.decode))))
     }
 }
@@ -641,7 +641,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A?]]] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
     }
 }
@@ -658,7 +658,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A?
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[[A]]]] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[[[A]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
     }
 }
@@ -675,7 +675,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[[A: B]]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[[A: B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }
 }
@@ -692,7 +692,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(A.decode))))
     }
 }
@@ -709,7 +709,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B?]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
     }
 }
@@ -726,7 +726,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: [B]]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: [B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
     }
 }
@@ -743,7 +743,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[[A: [B: C]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[[A: [B: C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -760,7 +760,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
     }
 }
@@ -777,7 +777,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(A.decode)))
     }
 }
@@ -794,7 +794,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]?]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -811,7 +811,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]?]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -828,7 +828,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
     }
 }
@@ -845,7 +845,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B?]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
     }
 }
@@ -862,7 +862,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [[B]]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [[B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -879,7 +879,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [[B: C]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [[B: C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -896,7 +896,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
     }
 }
@@ -913,7 +913,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C?]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
     }
 }
@@ -930,7 +930,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
     }
 }
@@ -947,7 +947,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C: D]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C: D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
     }
 }
@@ -964,7 +964,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
     }
 }
@@ -981,7 +981,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
     }
 }
@@ -998,7 +998,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A] {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> [A] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(A.decode))
     }
 }
@@ -1015,7 +1015,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A] {
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode)))))
     }
 }
@@ -1032,7 +1032,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -1049,7 +1049,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]?] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -1066,7 +1066,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))
     }
 }
@@ -1083,7 +1083,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]?] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
     }
 }
@@ -1100,7 +1100,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]?] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
     }
 }
@@ -1117,7 +1117,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]?] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
     }
 }
@@ -1134,7 +1134,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
     }
 }
@@ -1151,7 +1151,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))
     }
 }
@@ -1168,7 +1168,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]?]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -1185,7 +1185,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]?]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -1202,7 +1202,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))
     }
 }
@@ -1219,7 +1219,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B?]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode)))))
     }
 }
@@ -1236,7 +1236,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[[B]]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[[B]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -1253,7 +1253,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[[B: C]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[[B: C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -1270,7 +1270,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))
     }
 }
@@ -1287,7 +1287,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C?]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
     }
 }
@@ -1304,7 +1304,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
     }
 }
@@ -1321,7 +1321,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C: D]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C: D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
     }
 }
@@ -1338,7 +1338,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
     }
 }
@@ -1355,7 +1355,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))
     }
 }
@@ -1372,7 +1372,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]?]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode)))))
     }
 }
@@ -1389,7 +1389,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]?]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
     }
 }
@@ -1406,7 +1406,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))
     }
 }
@@ -1423,7 +1423,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C?]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode)))))
     }
 }
@@ -1440,7 +1440,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode)))))
     }
 }
@@ -1457,7 +1457,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C: D]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C: D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
     }
 }
@@ -1474,7 +1474,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))
     }
 }
@@ -1491,7 +1491,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D?]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D?]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode)))))
     }
 }
@@ -1508,7 +1508,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode)))))
     }
 }
@@ -1525,7 +1525,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D: E]]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D: E]]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode)))))
     }
 }
@@ -1542,7 +1542,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decod
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))
     }
 }
@@ -1559,7 +1559,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]] {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))
     }
 }
@@ -1576,7 +1576,7 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B] {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B] {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: B.decode))
     }
 }
@@ -1593,7 +1593,7 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: String...) throws -> A {
+    public final func decode <A: Decodable>(_ keyPath: String...) throws -> A {
         return try parse(self, keyPath: KeyPath(keyPath), decoder: A.decode)
     }
 }
@@ -1610,7 +1610,7 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A {
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]?]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
     }
 }
@@ -1627,7 +1627,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]?]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
     }
 }
@@ -1644,7 +1644,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
     }
 }
@@ -1661,7 +1661,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]?]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
     }
 }
@@ -1678,7 +1678,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
     }
 }
@@ -1695,7 +1695,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
     }
 }
@@ -1712,7 +1712,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]?]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
     }
 }
@@ -1729,7 +1729,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }
 }
@@ -1746,7 +1746,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A?]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
     }
 }
@@ -1763,7 +1763,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]?]]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
     }
 }
@@ -1780,7 +1780,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]?]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
     }
 }
@@ -1797,7 +1797,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
     }
 }
@@ -1814,7 +1814,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A?]]]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
     }
 }
@@ -1831,7 +1831,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A]]]]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
     }
 }
@@ -1848,7 +1848,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A: B]]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A: B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
     }
 }
@@ -1865,7 +1865,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
     }
 }
@@ -1882,7 +1882,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B?]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
     }
 }
@@ -1899,7 +1899,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B]]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
     }
 }
@@ -1916,7 +1916,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B: C]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B: C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
     }
 }
@@ -1933,7 +1933,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
     }
 }
@@ -1950,7 +1950,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
     }
 }
@@ -1967,7 +1967,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]?]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
     }
 }
@@ -1984,7 +1984,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]?]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }
 }
@@ -2001,7 +2001,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
     }
 }
@@ -2018,7 +2018,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B?]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
     }
 }
@@ -2035,7 +2035,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B]]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
     }
 }
@@ -2052,7 +2052,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B: C]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B: C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }
 }
@@ -2069,7 +2069,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
     }
 }
@@ -2086,7 +2086,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C?]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
     }
 }
@@ -2103,7 +2103,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
     }
 }
@@ -2120,7 +2120,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C: D]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C: D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
     }
 }
@@ -2137,7 +2137,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -2154,7 +2154,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
     }
 }
@@ -2171,7 +2171,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A]? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Array.decoder(A.decode)))
     }
 }
@@ -2188,7 +2188,7 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
     }
 }
@@ -2205,7 +2205,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
     }
 }
@@ -2222,7 +2222,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]?]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }
 }
@@ -2239,7 +2239,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -2256,7 +2256,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]?]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
     }
 }
@@ -2273,7 +2273,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]?]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
     }
 }
@@ -2290,7 +2290,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]?]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
     }
 }
@@ -2307,7 +2307,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]?]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -2324,7 +2324,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B?]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B?]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
     }
 }
@@ -2341,7 +2341,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]?]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
     }
 }
@@ -2358,7 +2358,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]?]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }
 }
@@ -2375,7 +2375,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
     }
 }
@@ -2392,7 +2392,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B?]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
     }
 }
@@ -2409,7 +2409,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B]]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
     }
 }
@@ -2426,7 +2426,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B: C]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B: C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
     }
 }
@@ -2443,7 +2443,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
     }
 }
@@ -2460,7 +2460,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C?]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
     }
 }
@@ -2477,7 +2477,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
     }
 }
@@ -2494,7 +2494,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C: D]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C: D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
     }
 }
@@ -2511,7 +2511,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
     }
 }
@@ -2528,7 +2528,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
     }
 }
@@ -2545,7 +2545,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]?]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
     }
 }
@@ -2562,7 +2562,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]?]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
     }
 }
@@ -2579,7 +2579,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
     }
 }
@@ -2596,7 +2596,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C?]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
     }
 }
@@ -2613,7 +2613,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
     }
 }
@@ -2630,7 +2630,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C: D]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C: D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
     }
 }
@@ -2647,7 +2647,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
     }
 }
@@ -2664,7 +2664,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D?]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D?]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
     }
 }
@@ -2681,7 +2681,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
     }
 }
@@ -2698,7 +2698,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D: E]]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D: E]]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
     }
 }
@@ -2715,7 +2715,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
     }
 }
@@ -2732,7 +2732,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]]? {
+    public final func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
     }
 }
@@ -2749,7 +2749,7 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B]? {
+    public final func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B]? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
     }
 }
@@ -2766,7 +2766,7 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 }
 
 extension NSDictionary {
-    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> A? {
+    public final func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> A? {
         return try parse(self, keyPath: OptionalKeyPath(keyPath).markingFirst(required: false), decoder: Optional.decoder(A.decode))
     }
 }

--- a/Sources/Overloads.swift
+++ b/Sources/Overloads.swift
@@ -6,8 +6,13 @@
 //  Copyright © 2016 anviking. All rights reserved.
 //
 
-// 163 overloads were generated with the following return types:
+// 326 overloads were generated with the following return types:
 // [[A]?]?, [[A: B]?]?, [A?]?, [[A?]]?, [[[A]]]?, [[[A: B]]]?, [[A]]?, [[A: B?]]?, [[A: [B]]]?, [[A: [B: C]]]?, [[A: B]]?, [A]?, [A: [B]?]?, [A: [B: C]?]?, [A: B?]?, [A: [B?]]?, [A: [[B]]]?, [A: [[B: C]]]?, [A: [B]]?, [A: [B: C?]]?, [A: [B: [C]]]?, [A: [B: [C: D]]]?, [A: [B: C]]?, [A: B]?, A?, [[A?]?], [[[A]]?], [[[A: B]]?], [[A]?], [[A: B?]?], [[A: [B]]?], [[A: [B: C]]?], [[A: B]?], [A?], [[[A]?]], [[[A: B]?]], [[A?]], [[[A?]]], [[[[A]]]], [[[[A: B]]]], [[[A]]], [[[A: B?]]], [[[A: [B]]]], [[[A: [B: C]]]], [[[A: B]]], [[A]], [[A: [B]?]], [[A: [B: C]?]], [[A: B?]], [[A: [B?]]], [[A: [[B]]]], [[A: [[B: C]]]], [[A: [B]]], [[A: [B: C?]]], [[A: [B: [C]]]], [[A: [B: [C: D]]]], [[A: [B: C]]], [[A: B]], [A], [A: [B?]?], [A: [[B]]?], [A: [[B: C]]?], [A: [B]?], [A: [B: C?]?], [A: [B: [C]]?], [A: [B: [C: D]]?], [A: [B: C]?], [A: B?], [A: [[B]?]], [A: [[B: C]?]], [A: [B?]], [A: [[B?]]], [A: [[[B]]]], [A: [[[B: C]]]], [A: [[B]]], [A: [[B: C?]]], [A: [[B: [C]]]], [A: [[B: [C: D]]]], [A: [[B: C]]], [A: [B]], [A: [B: [C]?]], [A: [B: [C: D]?]], [A: [B: C?]], [A: [B: [C?]]], [A: [B: [[C]]]], [A: [B: [[C: D]]]], [A: [B: [C]]], [A: [B: [C: D?]]], [A: [B: [C: [D]]]], [A: [B: [C: [D: E]]]], [A: [B: [C: D]]], [A: [B: C]], [A: B], A
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -20,6 +25,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -30,6 +40,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A?]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -42,6 +57,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?]?
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -52,6 +72,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?]?
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -64,6 +89,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -74,6 +104,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -86,6 +121,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -96,6 +136,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]]
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -108,6 +153,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -118,6 +168,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -130,6 +185,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Array.decoder(A.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -140,6 +200,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(A.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -152,6 +217,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -162,6 +232,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -174,6 +249,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -184,6 +264,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -196,6 +281,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -206,6 +296,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -218,6 +313,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -228,6 +328,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -240,6 +345,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -250,6 +360,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -262,6 +377,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B]? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -272,6 +392,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: B]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> A? {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Optional.decoder(A.decode))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -284,6 +409,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(A.decode))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -294,6 +424,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A? {
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]?] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -306,6 +441,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -316,6 +456,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B]]?] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Array.decoder(A.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -328,6 +473,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Array.decoder(A.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -338,6 +488,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]?
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B?]?] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -350,6 +505,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -360,6 +520,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C]]?] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -372,6 +537,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Optional.decoder(A.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -382,6 +552,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A?] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Optional.decoder(A.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -394,6 +569,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -404,6 +584,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B]?]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Optional.decoder(A.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -416,6 +601,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Optional.decoder(A.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -426,6 +616,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A?]
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A?]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[[A]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -438,6 +633,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[[A: B]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -448,6 +648,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[[A: B]]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[[A]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Array.decoder(A.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -460,6 +665,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Array.decoder(A.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -470,6 +680,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A]
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: B?]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: [B]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -482,6 +697,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[[A: [B: C]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -492,6 +712,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[[A: [B: C]]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[[A: B]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -504,6 +729,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [[A]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Array.decoder(A.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -514,6 +744,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Array.decoder(A.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -526,6 +761,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -536,6 +776,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C]?]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -548,6 +793,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -558,6 +808,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B?]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [[B]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -570,6 +825,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [[B: C]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -580,6 +840,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [[B: C]]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: [B]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -592,6 +857,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -602,6 +872,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: C?]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -614,6 +889,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [[A: [B: [C: D]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -624,6 +904,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: [B: [C: D]]]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [[A: [B: C]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -636,6 +921,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [[A: B]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -646,6 +936,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [[A: B]] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> [A] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Array.decoder(A.decode))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -658,6 +953,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A] {
     return try parse(json, keyPath: keyPath, decoder: Array.decoder(A.decode))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -668,6 +968,11 @@ public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A] {
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B?]?] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -680,6 +985,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -690,6 +1000,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C]]?] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -702,6 +1017,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -712,6 +1032,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C?]?] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -724,6 +1049,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -734,6 +1064,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D]]?] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -746,6 +1081,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B?] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -756,6 +1096,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: B?] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -768,6 +1113,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -778,6 +1128,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C]?]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -790,6 +1145,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -800,6 +1160,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B?]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[[B]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -812,6 +1177,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[[B: C]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -822,6 +1192,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[[B: C]]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [[B]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -834,6 +1209,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -844,6 +1224,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: C?]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -856,6 +1241,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [[B: [C: D]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -866,6 +1256,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [[B: [C: D]]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [[B: C]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -878,6 +1273,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: [B]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -888,6 +1288,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -900,6 +1305,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -910,6 +1320,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D]?]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C?]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -922,6 +1337,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -932,6 +1352,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C?]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -944,6 +1369,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [[C: D]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -954,6 +1384,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [[C: D]]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: [C]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -966,6 +1401,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D?]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -976,6 +1416,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPa
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: D?]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode)))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -988,6 +1433,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode)))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: [D: E]]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -998,6 +1448,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: [C: [D: E]]]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: String...) throws -> [A: [B: [C: D]]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1010,6 +1465,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: String...) throws -> [A: [B: C]] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1020,6 +1480,11 @@ public func => <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: An
 public func => <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> [A: [B: C]] {
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: String...) throws -> [A: B] {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: Dictionary.decoder(key: A.decode, value: B.decode))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1032,6 +1497,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
     return try parse(json, keyPath: keyPath, decoder: Dictionary.decoder(key: A.decode, value: B.decode))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: String...) throws -> A {
+        return try parse(self, keyPath: KeyPath(keyPath), decoder: A.decode)
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1042,6 +1512,11 @@ public func => <A: Decodable, B: Decodable>(json: AnyObject, keyPath: KeyPath) t
 public func => <A: Decodable>(json: AnyObject, keyPath: KeyPath) throws -> A {
     return try parse(json, keyPath: keyPath, decoder: A.decode)
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1054,6 +1529,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Optional.decoder(A.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1064,6 +1544,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Array.decoder(A.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1076,6 +1561,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1086,6 +1576,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1098,6 +1593,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1108,6 +1608,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1120,6 +1625,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1130,6 +1640,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1142,6 +1657,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Optional.decoder(A.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1152,6 +1672,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Array.decoder(A.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1164,6 +1689,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1174,6 +1704,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1186,6 +1721,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Optional.decoder(A.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1196,6 +1736,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[[A]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[[A: B]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1208,6 +1753,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1218,6 +1768,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Array.decoder(A.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1230,6 +1785,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1240,6 +1800,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: [B]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: [B: C]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1252,6 +1817,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[[A: B]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1262,6 +1832,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[[A: B]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [[A]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1274,6 +1849,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Array.decoder(A.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1284,6 +1864,11 @@ public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1296,6 +1881,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1306,6 +1896,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: B?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1318,6 +1913,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1328,6 +1928,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [[B]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [[B: C]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1340,6 +1945,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1350,6 +1960,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1362,6 +1977,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1372,6 +1992,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: [C]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: [C: D]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1384,6 +2009,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: [B: C]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1394,6 +2024,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [[A: [B: C]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [[A: B]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1406,6 +2041,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(Dictionary.decoder(key: A.decode, value: B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> [A]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Array.decoder(A.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1416,6 +2056,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Array.decoder(A.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1428,6 +2073,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Optional.decoder(B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1438,6 +2088,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Array.decoder(B.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1450,6 +2105,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1460,6 +2120,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Array.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1472,6 +2137,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1482,6 +2152,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1494,6 +2169,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1504,6 +2184,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C]?]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B?]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1516,6 +2201,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Optional.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1526,6 +2216,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Array.decoder(B.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1538,6 +2233,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1548,6 +2248,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Optional.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1560,6 +2265,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Optional.decoder(B.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1570,6 +2280,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[[B]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Array.decoder(B.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[[B: C]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1582,6 +2297,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1592,6 +2312,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Array.decoder(B.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1604,6 +2329,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1614,6 +2344,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: [C]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: [C: D]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1626,6 +2361,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [[B: C]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1636,6 +2376,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [[B: C]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(Dictionary.decoder(key: B.decode, value: C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1648,6 +2393,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Array.decoder(B.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1658,6 +2408,11 @@ public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalK
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Array.decoder(C.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1670,6 +2425,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C?]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1680,6 +2440,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: C?]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Optional.decoder(C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1692,6 +2457,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Optional.decoder(C.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1702,6 +2472,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [[C]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Array.decoder(C.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [[C: D]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1714,6 +2489,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(Dictionary.decoder(key: C.decode, value: D.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1724,6 +2504,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Array.decoder(C.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D?]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1736,6 +2521,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Optional.decoder(D.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1746,6 +2536,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: A
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: [D]]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Array.decoder(D.decode))))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: [D: E]]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1758,6 +2553,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: Dictionary.decoder(key: D.decode, value: E.decode))))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: [C: D]]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1768,6 +2568,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable, E: Deco
 public func =>? <A: Decodable, B: Decodable, C: Decodable, D: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: [B: [C: D]]]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: Dictionary.decoder(key: C.decode, value: D.decode)))))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable, C: Decodable>(_ keyPath: OptionalKey...) throws -> [A: [B: C]]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
@@ -1780,6 +2585,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: Dictionary.decoder(key: B.decode, value: C.decode))))
 }
 
+extension NSDictionary {
+    public func decode <A: Decodable, B: Decodable>(_ keyPath: OptionalKey...) throws -> [A: B]? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
+    }}
+
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 
 /// - parameter json: An object from NSJSONSerialization, preferably a `NSDictionary`.
@@ -1790,6 +2600,11 @@ public func =>? <A: Decodable, B: Decodable, C: Decodable>(json: AnyObject, keyP
 public func =>? <A: Decodable, B: Decodable>(json: AnyObject, keyPath: OptionalKeyPath) throws -> [A: B]? {
     return try parse(json, keyPath: keyPath, decoder: Optional.decoder(Dictionary.decoder(key: A.decode, value: B.decode)))
 }
+
+extension NSDictionary {
+    public func decode <A: Decodable>(_ keyPath: OptionalKey...) throws -> A? {
+        return try parse(self, keyPath: OptionalKeyPath(keyPath), decoder: Optional.decoder(A.decode))
+    }}
 
 /// Retrieves the object at `path` from `json` and decodes it according to the return type
 /// 

--- a/Tests/KeyPathTests.swift
+++ b/Tests/KeyPathTests.swift
@@ -71,6 +71,7 @@ class OptionalKeyPathTests: XCTestCase {
     
     func testConversionFromKeyPath() {
         let keyPath1: OptionalKeyPath = "a" => "b" => "c"
+        let keyPath11: OptionalKeyPath = ["a", "b", "c".optional]
         XCTAssertEqual(keyPath1.keys, [
             OptionalKey(key: "a", isRequired: false),
             OptionalKey(key: "b", isRequired: true),

--- a/Tests/KeyPathTests.swift
+++ b/Tests/KeyPathTests.swift
@@ -36,21 +36,21 @@ class KeyPathTests: XCTestCase {
 class OptionalKeyPathTests: XCTestCase {
     func testCreateFromStringLiteral() {
         let keyPath: OptionalKeyPath = "a"
-        XCTAssertEqual(keyPath.keys, [OptionalKey(key: "a", isRequired: false)])
+        XCTAssertEqual(keyPath.keys, [OptionalKey(key: "a", isRequired: true)])
     }
     
     func testCreateFromArrayLiteral() {
         let keyPath: OptionalKeyPath = ["a", "b"]
         XCTAssertEqual(keyPath.keys, [
-            OptionalKey(key: "a", isRequired: false),
-            OptionalKey(key: "b", isRequired: false),
+            OptionalKey(key: "a", isRequired: true),
+            OptionalKey(key: "b", isRequired: true),
             ])
     }
     
     func testCreateWithOperators() {
         let keyPath: OptionalKeyPath = "a" =>? "b"
         XCTAssertEqual(keyPath.keys, [
-            OptionalKey(key: "a", isRequired: false),
+            OptionalKey(key: "a", isRequired: true),
             OptionalKey(key: "b", isRequired: false),
             ])
     }
@@ -60,9 +60,9 @@ class OptionalKeyPathTests: XCTestCase {
         let bAndC: OptionalKeyPath = ["b", "c"]
         let keyPath: OptionalKeyPath = a =>? bAndC
         XCTAssertEqual(keyPath.keys, [
-            OptionalKey(key: "a", isRequired: false),
+            OptionalKey(key: "a", isRequired: true),
             OptionalKey(key: "b", isRequired: false),
-            OptionalKey(key: "c", isRequired: false)
+            OptionalKey(key: "c", isRequired: true)
             ])
     }
     
@@ -71,23 +71,22 @@ class OptionalKeyPathTests: XCTestCase {
     
     func testConversionFromKeyPath() {
         let keyPath1: OptionalKeyPath = "a" => "b" => "c"
-        let keyPath11: OptionalKeyPath = ["a", "b", "c".optional]
         XCTAssertEqual(keyPath1.keys, [
-            OptionalKey(key: "a", isRequired: false),
+            OptionalKey(key: "a", isRequired: true),
             OptionalKey(key: "b", isRequired: true),
             OptionalKey(key: "c", isRequired: true)
             ])
         
         let keyPath2: OptionalKeyPath = "a" =>? "b" => "c"
         XCTAssertEqual(keyPath2.keys, [
-            OptionalKey(key: "a", isRequired: false),
+            OptionalKey(key: "a", isRequired: true),
             OptionalKey(key: "b", isRequired: false),
             OptionalKey(key: "c", isRequired: true)
             ])
         
         let keyPath3: OptionalKeyPath = "a" => "b" =>? "c"
         XCTAssertEqual(keyPath3.keys, [
-            OptionalKey(key: "a", isRequired: false),
+            OptionalKey(key: "a", isRequired: true),
             OptionalKey(key: "b", isRequired: true),
             OptionalKey(key: "c", isRequired: false)
             ])


### PR DESCRIPTION
Adds overloads of the following form:
```swift
extension NSDictionary {
    public func decode <A: Decodable>(_ keyPath: String...) throws -> A { ... }
}
```

Which enables the following usage:
```swift
let _: String = dict.decode("a", "b")
let _: String? = dict.decode("a", OptionalKey("b"))
```

With the side effects of making the `OptionalKeyPath`/`KeyPath` slightly more complex and with changes to default behaviours:

```swift
// OptionalKeys created from string literals have isRequired = true
let a1: OptionalKeyPath = ["a", "b"] // a.b

// OptionalKeys created with explicit initialiser have isRequired = false
let a2: OptionalKeyPath = ["a", OptionalKey("b")] // a.b?
```

I thought about adding a `.optional` property on `String` instead of `OptionalKey("key")`, but thought it was too vague.

This would fix #26, while maintaining the following features:
- Keys that are allowed to be missing have to be explicitly (and individually) marked
- No wrapping JSON type
- Previous syntax still works

I'm not at all sold on this yet however. Some rambling thoughts:
- The operator way and non-operator way cannot presumably live side by side forever
- When dealing with dictionaries disguised as `AnyObject`s this adds verbosity
- When dealing with optional keys this adds verbosity and removes the illusion that `=>` works like a subscript, and the added ? in `=>?` works like in optional chaining. Though perhaps this is for the best because the implementation is made simpler, fixes one edge cases where the first key(s) are required where the latter are optional, and because this is how Decodable actually works.

Also in the future `OptionalKey` could add functionality to distinguish between accepting `NSNull` and accepting missing keys, a small but useful feature. 

### TODO:
- Fix documentation
- Think about it for a while
