### PR TITLE
Expose KeyPath.keys, make KeyPath Equatable

### DIFF
--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -18,7 +18,7 @@ import Foundation
 /// ```
 
 public struct KeyPath {
-    var keys: [String]
+    public var keys: [String]
     
     public init(_ keys: [String]) {
         self.keys = keys
@@ -48,4 +48,9 @@ extension KeyPath: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: String...) {
         self.keys = elements
     }
+}
+
+extension KeyPath: Equatable { }
+public func ==(lhs: KeyPath, rhs: KeyPath) -> Bool {
+    return lhs.keys == rhs.keys
 }


### PR DESCRIPTION
I use this pattern to group the keys that I use in a `Decodable` type:

```swift
struct MyDecodableType: Decodable {
    enum Keys: KeyPath {
        case foo = "foo"
        case bar = "bar"
    }
}
```

I used to make those `Keys` enum have an associated `String` value, but with the switch to `KeyPath`, in order to be able to use `KeyPath` as the raw value of an enum, it needs to conform to `Equatable`.