### PR TITLE
Help Xcode 8 understand that the code is Swift 3 [CocoaPods]

### DIFF
--- a/Decodable.podspec
+++ b/Decodable.podspec
@@ -13,4 +13,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.requires_arc = true
   s.source_files = 'Sources/*.{swift,h}'
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0' }
 end


### PR DESCRIPTION
Unfortunately when installing Decodable using CocoaPods, the generated Xcode project is missing the `SWIFT_VERSION` build setting. This can be fixed by adding `s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0' }` to the Podspec (see commit).

The compile error from Xcode 8: `"Use Legacy Swift Language Version" (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.`

(Note: I have not updated the version in the Podspec.)