### PR TITLE
Introduce generic typealias for decoder closures

### DIFF
--- a/Sources/Castable.swift
+++ b/Sources/Castable.swift
@@ -31,7 +31,7 @@ public protocol DynamicDecodable {
     /// from their `decode` function.
     ///
     /// - note: This is intended as a set-once thing.
-    static var decoder: (Any) throws -> DecodedType {get set}
+    static var decoder: Decoder<DecodedType> {get set}
 }
 
 extension Decodable where Self: DynamicDecodable, Self.DecodedType == Self {
@@ -42,16 +42,16 @@ extension Decodable where Self: DynamicDecodable, Self.DecodedType == Self {
 }
 
 extension String: Decodable, DynamicDecodable {
-    public static var decoder: (Any) throws -> String = { try cast($0) }
+    public static var decoder: Decoder<String> = { try cast($0) }
 }
 extension Int: Decodable, DynamicDecodable {
-    public static var decoder: (Any) throws -> Int = { try cast($0) }
+    public static var decoder: Decoder<Int> = { try cast($0) }
 }
 extension Double: Decodable, DynamicDecodable {
-    public static var decoder: (Any) throws -> Double = { try cast($0) }
+    public static var decoder: Decoder<Double> = { try cast($0) }
 }
 extension Bool: Decodable, DynamicDecodable {
-    public static var decoder: (Any) throws -> Bool = { try cast($0) }
+    public static var decoder: Decoder<Bool> = { try cast($0) }
 }
 
 private let iso8601DateFormatter: DateFormatter = {
@@ -63,7 +63,7 @@ private let iso8601DateFormatter: DateFormatter = {
 
 extension Date: Decodable, DynamicDecodable {
     /// Default decoder is `Date.decoder(using: iso8601DateFormatter)`
-    public static var decoder: (Any) throws -> Date = Date.decoder(using: iso8601DateFormatter)
+    public static var decoder: Decoder<Date> = Date.decoder(using: iso8601DateFormatter)
     
     /// Create a decode closure using a given formatter
     ///
@@ -92,7 +92,7 @@ extension NSDictionary: Decodable {
 }
 
 extension NSArray: DynamicDecodable {
-    public static var decoder: (Any) throws -> NSArray = { try cast($0) }
+    public static var decoder: Decoder<NSArray> = { try cast($0) }
     public static func decode(_ json: Any) throws -> NSArray {
         return try decoder(json)
     }

--- a/Sources/Decoders.swift
+++ b/Sources/Decoders.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+public typealias Decoder<DecodedType> = (Any) throws -> DecodedType
+
 extension Optional {
     
     /// Creates an optional decoder from a decoder of the Wrapped type
@@ -16,7 +18,7 @@ extension Optional {
     ///
     /// - parameter wrappedDecoder: A decoder (decode closure) for the wrapped type
     /// - returns: A closure takes an JSON object, checks it's `NSNull`, if so returns `nil`, otherwise calls the wrapped decode closure.
-    static func decoder(_ wrappedDecoder: @escaping (Any) throws -> Wrapped) -> (Any) throws -> Wrapped? {
+    static func decoder(_ wrappedDecoder: @escaping Decoder<Wrapped>) -> Decoder<Wrapped?> {
         return { json in
             if json is NSNull {
                 return nil
@@ -36,7 +38,7 @@ extension Array {
     /// - parameter elementDecoder: A decoder (decode closure) for the `Element` type
     /// - throws: if `NSArray.decode` throws or any element decode closure throws
     /// - returns: A closure that takes an `NSArray` and maps it using the element decode closure
-    public static func decoder(_ elementDecoder: @escaping (Any) throws -> Element) -> (Any) throws -> Array<Element> {
+    public static func decoder(_ elementDecoder: @escaping Decoder<Element>) -> Decoder<[Element]> {
         return { json in
             return try NSArray.decode(json).map { try elementDecoder($0) }
         }
@@ -51,7 +53,7 @@ extension Dictionary {
     /// - parameter key: A decoder (decode closure) for the `Key` type
     /// - parameter value: A decoder (decode closure) for the `Value` type
     /// - returns: A closure that takes a `NSDictionary` and "maps" it using key and value decode closures
-    public static func decoder(key keyDecoder: @escaping (Any) throws -> Key, value valueDecoder: @escaping (Any) throws -> Value) -> (Any) throws -> Dictionary {
+    public static func decoder(key keyDecoder: @escaping Decoder<Key>, value valueDecoder: @escaping Decoder<Value>) -> Decoder<[Key:Value]> {
         return { json in
             var dict = Dictionary()
             for (key, value) in try NSDictionary.decode(json) {


### PR DESCRIPTION
I think this is a good opportunity to try out the new generic typealiases. Perfect for shortening definitions of callbacks, etc.