### PR TITLE
Replace (Void) with () to remove xcode-9 / swift 4 warnings

### DIFF
--- a/Sources/Parse.swift
+++ b/Sources/Parse.swift
@@ -56,7 +56,7 @@ public func parse<T>(_ json: Any, keyPath: OptionalKeyPath, decoder: ((Any) thro
 
 // MARK: - Helpers
 
-func catchMissingKeyAndReturnNil<T>(_ closure: (Void) throws -> T) throws -> T? {
+func catchMissingKeyAndReturnNil<T>(_ closure: () throws -> T) throws -> T? {
     do {
         return try closure()
     } catch DecodingError.missingKey {
@@ -64,7 +64,7 @@ func catchMissingKeyAndReturnNil<T>(_ closure: (Void) throws -> T) throws -> T? 
     }
 }
 
-func catchAndRethrow<T>(_ json: Any, _ keyPath: KeyPath, block: (Void) throws -> T) throws -> T {
+func catchAndRethrow<T>(_ json: Any, _ keyPath: KeyPath, block: () throws -> T) throws -> T {
     do {
         return try block()
     } catch let error as DecodingError {
@@ -77,7 +77,7 @@ func catchAndRethrow<T>(_ json: Any, _ keyPath: KeyPath, block: (Void) throws ->
     }
 }
 
-func catchAndRethrow<T>(_ json: Any, _ keyPath: OptionalKeyPath, block: (Void) throws -> T) throws -> T {
+func catchAndRethrow<T>(_ json: Any, _ keyPath: OptionalKeyPath, block: () throws -> T) throws -> T {
     do {
         return try block()
     } catch let error as DecodingError {


### PR DESCRIPTION
Trivial syntax change to remove some warnings from Xcode 9 (or, technically, from swift 4 I guess)